### PR TITLE
Meal編集ページのJs設定

### DIFF
--- a/app/assets/javascripts/post.js
+++ b/app/assets/javascripts/post.js
@@ -1,11 +1,16 @@
 $(function() {
   var $textarea = $('#textarea');
+  var $textarea2 = $('#textarea2');
   var lineHeight = parseInt($textarea.css('lineHeight'));
   $textarea.on('input', function(e) {
     var lines = ($(this).val() + '\n').match(/\n/g).length;
     $(this).height(lineHeight * lines);
   });
-
+  // Meal編集画面２個目のtextarea用Js
+  $textarea2.on('input', function(e) {
+    var lines = ($(this).val() + '\n').match(/\n/g).length;
+    $(this).height(lineHeight * lines);
+  });
   //画像ファイルプレビュー表示のイベント追加 fileを選択時に発火するイベントを登録
   $('.photo-form').on('change', 'input[type="file"]', function(e) {
     var file = e.target.files[0],

--- a/app/assets/stylesheets/posts/new.scss
+++ b/app/assets/stylesheets/posts/new.scss
@@ -76,7 +76,7 @@
       top: 40%;
     }
   }
-  #textarea {
+  #textarea, #textarea2 {
     width: 280px;
     max-height: 200px;
     margin: 20px 10px;

--- a/app/controllers/meals_controller.rb
+++ b/app/controllers/meals_controller.rb
@@ -54,6 +54,7 @@ class MealsController < ApplicationController
                                 :image,
                                 :food_stuff,
                                 :cooking_time,
+                                :cooking_method,
                                 :remove_image
                                 ).merge(user_id: current_user.id)
   end

--- a/app/views/meals/edit.html.erb
+++ b/app/views/meals/edit.html.erb
@@ -33,7 +33,7 @@
           <%= f.label :任意, class:'form-any-require' %>
         </div>
         <div class="text-form-box">
-          <%= f.text_area :cooking_method, placeholder: '例）沸騰したお湯に切った野菜を入れる', id:'textarea' %>
+          <%= f.text_area :cooking_method, placeholder: '例）沸騰したお湯に切った野菜を入れる', id:'textarea2' %>
         </div>
         <div class="form-registration-box">
           <%= f.label :画像, class:'new-name-form' %>

--- a/app/views/meals/new.html.erb
+++ b/app/views/meals/new.html.erb
@@ -40,7 +40,7 @@
           <%= f.label :任意, class:'form-any-require' %>
         </div>
         <div class="text-form-box">
-          <%= f.text_area :cooking_method, placeholder: '例）沸騰したお湯に切った野菜を入れる', id:'textarea' %>
+          <%= f.text_area :cooking_method, placeholder: '例）沸騰したお湯に切った野菜を入れる', id:'textarea2' %>
         </div>
         <div class="form-registration-box">
           <%= f.label :画像, class:'new-name-form' %>


### PR DESCRIPTION
## WHAT

- 調理方法と食材のtextarea両方でJsを発火させる

## WHY

Js無しのtextareaではスクロースが必要になりユーザーが入力したテキストが見にくくなってしまう為、Jsを使ってスクロース作業を無くした

## IMAGE

![demo](https://gyazo.com/5213726365c4c5c6af35070602dd0be8/raw)