### PR TITLE
ユーザープロフィールを追加

### DIFF
--- a/app/assets/stylesheets/posts/show.scss
+++ b/app/assets/stylesheets/posts/show.scss
@@ -3,10 +3,26 @@
   width: 800px;
   margin: 0 auto;
   background: white;
+  .user-info-top {
+    display: flex;
+    padding-top: 5px;
+    .detail-user-name {
+      font-size: 20px;
+      color: black;
+      font-weight: bold;
+      margin: 20px 0;
+    }
+    .user-face {
+      border-radius: 50%;
+      width: 40px;
+      margin: 15px;
+    }
+  }
   .detail-post-container {
     width: 100%;
     text-align: center;
     .detail-name {
+      border-top: solid 1px #f5f3f4;
       font-size: 32px;
       padding: 10px;
     }

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -19,7 +19,6 @@ body {
     color: white;
     text-align: center;
   }
-
 }
 .new-icon {
   margin-top: 20px;
@@ -80,6 +79,11 @@ body {
           label {
             font-size: 18px;
           }
+        }
+        .user-face {
+          border-radius: 50%;
+          width: 40px;
+          margin: 15px;
         }
       }
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,8 @@ class ApplicationController < ActionController::Base
   before_action :set_search
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :profile])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nickname, :profile])
   end
 
   def search

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   def index
     @posts = Post.includes(:user).order('updated_at DESC')
+    @users = User.all.order('updated_at DESC')
     @meals = Meal.includes(:user).order('updated_at DESC')
     if user_signed_in?
         @current_user_posts=Post.where(user_id:current_user.id).order('updated_at DESC')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,5 @@ class User < ApplicationRecord
   has_many :meals, dependent: :destroy
   has_many :comments
   has_many :likes, dependent: :destroy
-  validates :nickname, presence: true
+  validates :nickname, :profile, presence: true
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,6 +28,12 @@
           <%= f.text_field :nickname, placeholder: 'ニックネームを入力', maxlength: "6", class:'new-part-form' %>
         </div>
         <div class="form-registration-box">
+          <%= f.label :profile, class:'new-name-form' %>
+        </div>
+        <div class="text-form-box">
+          <%= f.text_area :profile, placeholder: '自己紹介しよう！', class:'new-part-form', id:'textarea' %>
+        </div>
+        <div class="form-registration-box">
           <%= f.label :新しいパスワード, class:'new-name-form' %>
         </div>
         <div class="form-registration-box">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,48 +1,54 @@
 <body>
   <%= render "layouts/shared/header" %>
-  <div class="new-post-box">
-    <div class="new-post-container">
-      <div class="new-name">
-        新規会員登録
-      </div>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
+    <div class="new-post-box">
+      <div class="new-post-container">
+        <div class="new-name">
+          新規会員登録
+        </div>
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= render "devise/shared/error_messages", resource: resource %>
 
-        <div class="form-registration-box">
-          <%= f.label :email, class:'new-name-form' %>
-        </div>
-        <div class="text-form-box">
-          <%= f.email_field :email, autofocus: true, placeholder: 'メールアドレスを入力', class:'new-part-form' %>
-        </div>
-        <div class="form-registration-box">
-          <%= f.label :nickname, class:'new-name-form' %><br/>
-          (6文字以内)
-        </div>
-        <div class="text-form-box">
-          <%= f.text_field :nickname, placeholder: 'ニックネームを入力', maxlength: "6", class:'new-part-form' %>
-        </div>
-        <div class="form-registration-box">
-          <%= f.label :パスワード, class:'new-name-form' %>
-        </div>
-        <div class="form-registration-box">
-          <% if @minimum_password_length %>
-          <em>(<%= @minimum_password_length %> 文字以上)</em>
-          <% end %>
-        </div>
-        <div class="text-form-box">
-          <%= f.password_field :password, placeholder: 'パスワードを入力', autocomplete: "new-password", class:'new-part-form' %>
-        </div>
-        <div class="form-registration-box">
-          <%= f.label :パスワード再入力, class:'new-name-form' %>
-        </div>
-        <div class="text-form-box">
-          <%= f.password_field :password_confirmation, placeholder: 'パスワードをもう一度入力', autocomplete: "new-password", class:'new-part-form' %>
-        </div>
-        <%= f.submit "登録する", class:'new-form-btn' %>
-      <% end %>
-      既にアカウントをお持ちですか？
-      <%= render "devise/shared/links" %>
+          <div class="form-registration-box">
+            <%= f.label :email, class:'new-name-form' %>
+          </div>
+          <div class="text-form-box">
+            <%= f.email_field :email, autofocus: true, placeholder: 'メールアドレスを入力', class:'new-part-form' %>
+          </div>
+          <div class="form-registration-box">
+            <%= f.label :nickname, class:'new-name-form' %><br/>
+            (6文字以内)
+          </div>
+          <div class="text-form-box">
+            <%= f.text_field :nickname, placeholder: 'ニックネームを入力', class:'new-part-form' %>
+          </div>
+          <div class="form-registration-box">
+            <%= f.label :profile, class:'new-name-form' %>
+          </div>
+          <div class="text-form-box">
+            <%= f.text_area :profile, placeholder: '自己紹介しよう！', class:'new-part-form', id:'textarea' %>
+          </div>
+          <div class="form-registration-box">
+            <%= f.label :パスワード, class:'new-name-form' %>
+          </div>
+          <div class="form-registration-box">
+            <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> 文字以上)</em>
+            <% end %>
+          </div>
+          <div class="text-form-box">
+            <%= f.password_field :password, placeholder: 'パスワードを入力', autocomplete: "new-password", class:'new-part-form' %>
+          </div>
+          <div class="form-registration-box">
+            <%= f.label :パスワード再入力, class:'new-name-form' %>
+          </div>
+          <div class="text-form-box">
+            <%= f.password_field :password_confirmation, placeholder: 'パスワードをもう一度入力', autocomplete: "new-password", class:'new-part-form' %>
+          </div>
+          <%= f.submit "登録する", class:'new-form-btn' %>
+        <% end %>
+        既にアカウントをお持ちですか？
+        <%= render "devise/shared/links" %>
+      </div>
     </div>
-  </div>
   <%= render "layouts/shared/footer" %>
 </body>

--- a/app/views/layouts/shared/_header.html.erb
+++ b/app/views/layouts/shared/_header.html.erb
@@ -26,7 +26,9 @@
       <%= link_to "山メシを投稿", new_meal_path, class:'user-link-meshi header' %>
     </div>
     <div class="user-link">
-      <%= link_to "マイページ (仮)", "#", class:'user-link-meshi header' %>
+      <%= link_to "#", class:'user-link-meshi header' do %>
+        マイページ
+      <% end %>
     </div>
     <div class="logout-btn">
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:'user-link-logout' %>

--- a/app/views/meals/partial/_new-meals.html.erb
+++ b/app/views/meals/partial/_new-meals.html.erb
@@ -1,25 +1,17 @@
 <div class="middle-container">
   <div class="post-title-container">
-    <h2 class="list-title">山メシ最新投稿</h2>
+    <h2 class="list-title">ユーザー一覧</h2>
     <div class="new-icon">
       <p>new</p>
     </div>
   </div>
   <div class="latest-posts">
-    <% @meals.each do |meal| %>
-      <%= link_to "meals/#{ meal.id }" do %>
+    <% @users.each do |user| %>
+      <%= link_to "users/#{ user.id }" do %>
         <div class="post-box">
-          <div class="post-picture">
-            <% if meal.image.present? %>
-              <%= image_tag meal.image.url, class:"post-yama-picture"%>
-            <% else %>
-              <%= image_tag"no_image.png", class:"post-yama-picture"%>
-            <% end %>
-          </div>
+          <img class="user-face" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
           <div class="post-yama-description">
-            <label><%= meal.user.nickname %>さんの投稿</label>
-            <div class="post-yama-display name"><%= meal.name %></div>
-            <div class="post-latest-comment"><%= meal.food_stuff %></div>
+            <label><%= user.nickname %>さんの投稿</label>
           </div>
         </div>
       <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
   <main>
     <div class="large-container">
       <%= render "posts/partial/new-posts"%>
-      <%= render "meals/partial/new-meals"%>
+      <%= render "users/user-lists"%>
       <%= render "posts/partial/mypage-box"%>
     </div>
     <div id="main-container">

--- a/app/views/posts/partial/_mypage-box.html.erb
+++ b/app/views/posts/partial/_mypage-box.html.erb
@@ -8,7 +8,7 @@
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:'user-link-logout' %>
       </div>
       <div class="profile-btn">
-        <%= link_to 'プロフィール変更', edit_user_registration_path, class:'user-link-profile' %>
+        <%= link_to 'プロフィール変更', edit_user_registration_path, class:'user-link-profile',data: {"turbolinks"=>false} %>
       </div>
     </div>
     <div class="responsive-user-box">
@@ -40,7 +40,7 @@
       </div>
       <div class="user-link">
         <%= link_to "ログイン", new_user_session_path, class:'user-link-meshi' %>
-        <%= link_to "新規登録", new_user_registration_path, class:'user-link-meshi' %>
+        <%= link_to "新規登録", new_user_registration_path, class:'user-link-meshi',data: {"turbolinks"=>false} %>
       </div>
     </div>
 <% end %>

--- a/app/views/posts/partial/_yama-lists.html.erb
+++ b/app/views/posts/partial/_yama-lists.html.erb
@@ -24,7 +24,7 @@
             <%= post.difficulty_i18n %>
           </div>
         </div>
-        <label>hogeさんの一言コメント</label>
+        <label><%= post.user.nickname %>さんの一言コメント</label>
         <div class="latest-comment">
           <%= post.text %>
         </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,12 @@
 <body>
 <%= render "layouts/shared/header" %>
   <div class="detail-post-box">
+    <div class="user-info-top">
+      <img class="user-face" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+      <div class="detail-user-name">
+        <%= @post.user.nickname %>
+      </div>
+    </div>
     <div class="detail-post-container">
       <div class="detail-name">
         <%= @post.name %>

--- a/app/views/users/_user-lists.html.erb
+++ b/app/views/users/_user-lists.html.erb
@@ -1,0 +1,17 @@
+<div class="middle-container">
+  <div class="post-title-container">
+    <h2 class="list-title">ユーザー一覧</h2>
+  </div>
+  <div class="latest-posts">
+    <% @users.each do |user| %>
+      <%= link_to "users/#{ user.id }" do %>
+        <div class="post-box">
+          <img class="user-face" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+          <div class="post-yama-description">
+            <label><%= user.nickname %>さん</label>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -8,6 +8,7 @@ ja:
         password_confirmation: "確認用パスワード"
         remember_me: "ログインを記憶"
         nickname: "ニックネーム"
+        profile: "自己紹介"
     models:
       user: "ユーザ"
   devise:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,24 @@
 Rails.application.routes.draw do
 
   devise_for :users
+
   root 'posts#index'
+
   resources :posts do
     resources :likes, only: [:create, :destroy]
     resources :comments, only: [:create]
+    resources :users, only: [:index, :show]
     collection do
       get 'search'
     end
   end
+  resources :users do
+    member do
+      get :following, :followers
+    end
+  end
+  resources :relationships,only: [:create, :destroy]
+
   resources :meals
+
 end

--- a/db/migrate/20191008014238_add_column_to_users.rb
+++ b/db/migrate/20191008014238_add_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :profile, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_04_071901) do
+ActiveRecord::Schema.define(version: 2019_10_08_014238) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2019_10_04_071901) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nickname", default: "", null: false
+    t.text "profile", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+5.times do |i|
+  User.create!(email: "test#{i + 1}@example.com", password: "password", password_confirmation: "password", nickname: "ニックネーム#{i + 1}", profile: "宜しくお願いします！")
+end


### PR DESCRIPTION
## WHAT

- プロフィールカラムの追加
- userのルーティング設定
- topページにユーザー一覧表示

## WHY

- ユーザーフォロー機能実装するにあたり登録しているユーザーのプロフィールが確認できる方がユーザーフレンドリーの為

## IMAGE

- topページのユーザー一覧
![スクリーンショット 2019-10-08 11 14 45](https://user-images.githubusercontent.com/51276845/66362327-43f91980-e9bd-11e9-9d41-d378379916f9.png)
- サインアップ画面のプロフィール欄
![screencapture-localhost-3001-users-sign-up-2019-10-08-11_15_09](https://user-images.githubusercontent.com/51276845/66362339-596e4380-e9bd-11e9-8669-37b618b20650.png)
