### PR TITLE
スマホサイズ用footer作成

### DIFF
--- a/app/assets/stylesheets/posts/footer.scss
+++ b/app/assets/stylesheets/posts/footer.scss
@@ -1,4 +1,8 @@
+.sp-footer-main {
+  display: none !important;
+}
 .footer-main {
+  display: block !important;
   background: green;
   width: 100%;
   height: 70px;
@@ -21,5 +25,29 @@
     text-align: center;
     margin: 10px;
     color: white;
+  }
+}
+@media screen and (max-width: 500px) {
+  .footer-main {
+    display: none !important;
+  }
+  .sp-footer-main {
+    display: block !important;
+    width: 500px;
+    height: 110px;
+    padding: 5px 0;
+    background: green;
+    &__link {
+      text-align: center;
+      text-decoration: none;
+      &__information {
+        margin: 5px 0 0 0;
+        color: white;
+      }
+    }
+    &__copyright {
+      color: white;
+      text-align: center;
+    }
   }
 }

--- a/app/assets/stylesheets/posts/header.scss
+++ b/app/assets/stylesheets/posts/header.scss
@@ -64,9 +64,11 @@
     width: 500px;
     height: 80px;
     position: relative;
-    .fas.fa-bars {
+    .fa.fa-search {
       color: white;
-      margin: 25px 10px;
+      position: absolute;
+      right: 10px;
+      top: 25px;
     }
     .logo-box {
       position: absolute;
@@ -87,16 +89,12 @@
       height: auto;
       max-height: 50px;
       margin: 5px 0 0 10px;
-      position: absolute;
-      right: 10px;
-      top: 10px;
+      margin: 12px 10px;
       border: solid 2px white;
     }
     .fas.fa-user {
       color: white;
-      position: absolute;
-      right: 10px;
-      top: 25px;
+      margin: 25px 10px;
     }
   }
   .sidebar {

--- a/app/views/layouts/shared/_sp-footer.html.erb
+++ b/app/views/layouts/shared/_sp-footer.html.erb
@@ -1,0 +1,14 @@
+<footer class="sp-footer-main">
+  <%= link_to usage_posts_path, class:'sp-footer-main__link' do %>
+    <div class="sp-footer-main__link__information">使い方</div>
+  <% end %>
+  <%= link_to notification_posts_path, class:'sp-footer-main__link' do %>
+    <div class="sp-footer-main__link__information">お知らせ</div>
+  <% end %>
+  <%= link_to about_posts_path, class:'sp-footer-main__link' do %>
+    <div class="sp-footer-main__link__information">このサイトについて</div>
+  <% end %>
+  <div class="sp-footer-main__copyright">
+    <a>Copyright（C） 2019　kohei sugawara All Rights Reserved.</a>
+  </div>
+</footer>

--- a/app/views/layouts/shared/_sp-header.html.erb
+++ b/app/views/layouts/shared/_sp-header.html.erb
@@ -1,9 +1,4 @@
 <header class="sp-header-main">
-  <i class="fas fa-bars fa-2x"></i>
-  <%= link_to root_path, class:'logo-box' do %>
-    <h1 class="logo-box__sp-logo">岳人</h1>
-    <h3 class="logo-box__sp-kana">〜たけと〜</h3>
-  <% end %>
   <% if user_signed_in? %>
     <% if current_user.image.present? %>
       <%= image_tag current_user.image.url, class:"user-face" %>
@@ -28,4 +23,9 @@
       <%= link_to "新規登録", new_user_registration_path, class:'sidebar__link-path',data: {"turbolinks"=>false} %>
     <% end %>
   </aside>
+  <i class="fa fa-search fa-2x"></i>
+  <%= link_to root_path, class:'logo-box' do %>
+    <h1 class="logo-box__sp-logo">岳人</h1>
+    <h3 class="logo-box__sp-kana">〜たけと〜</h3>
+  <% end %>
 </header>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -25,4 +25,5 @@
     </div>
   </main>
   <%= render "layouts/shared/footer" %>
+  <%= render "layouts/shared/sp-footer" %>
 </body>


### PR DESCRIPTION
## WHAT

- スマホサイズ用footer作成。

## WHY

- デバイスフレンドリーなレイアウトにする為。

## IMAGE

![スクリーンショット 2019-10-20 15 32 09](https://user-images.githubusercontent.com/51276845/67155786-617c9a80-f350-11e9-8ea9-d483b69a5a22.png)
