### PR TITLE
スマホ用ユーザー一覧作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'devise'
 gem 'devise-i18n'
 gem 'devise-i18n-views'
 gem 'pry-rails'
-gem 'jquery-turbolinks'
 gem 'ransack'
 gem 'kaminari'
 gem 'faker'
@@ -30,7 +29,6 @@ gem 'jquery-rails'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,9 +151,6 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-turbolinks (2.1.0)
-      railties (>= 3.1.0)
-      turbolinks
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -300,9 +297,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -348,7 +342,6 @@ DEPENDENCIES
   font-awesome-rails
   jbuilder (~> 2.5)
   jquery-rails
-  jquery-turbolinks
   kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick (= 4.7.0)
@@ -363,7 +356,6 @@ DEPENDENCIES
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   unicorn (= 5.5.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,5 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require turbolinks
 //= require activestorage
 //= require_tree .

--- a/app/assets/javascripts/sp-header.js
+++ b/app/assets/javascripts/sp-header.js
@@ -5,13 +5,4 @@ $(function() {
   $('.fas.fa-user').click(function() {
     $('.sidebar').toggle(500);
   })
-
-  $('.fa.fa-search').on('click',function(){
-      $('.js-modal').fadeIn(100);
-      return false;
-  });
-  $('.js-modal-close').on('click',function(){
-      $('.js-modal').fadeOut(100);
-      return false;
-  });
 });

--- a/app/assets/stylesheets/modules/_sp-banner.scss
+++ b/app/assets/stylesheets/modules/_sp-banner.scss
@@ -12,10 +12,10 @@
       background: white;
       display: flex;
       justify-content: space-between;
-      border-bottom: 1px solid gray;
-      .fas {
+      border-top: 1px solid gray;
+      .fas, .fa {
         color: gray;
-        margin: 15px 20px;
+        margin: 10px 15px;
       }
     }
   }

--- a/app/assets/stylesheets/posts/header.scss
+++ b/app/assets/stylesheets/posts/header.scss
@@ -156,43 +156,22 @@
       position: absolute;
       opacity: 0.7;
   }
-  .modal__content{
-    width: 200px;
+  .search-box {
+    padding-left: 10px;
+    margin-top: 10px;
+    width: 100%;
+    height: 40px;
+    border: solid 0.5px #fff;
+    line-height: 30px;
+    background: white;
+  }
+  .search-btn {
+    width: 50px;
     position: absolute;
-    left: 50%;
-    top: 60px;
-    transform: translate(-50%,-50%);
-    &__search-box {
-      padding-left: 10px;
-      margin-top: 10px;
-      width: 100%;
-      height: 40px;
-      border: solid 0.5px #fff;
-      line-height: 30px;
-      background: white;
-    }
-    &__search-btn {
-      width: 50px;
-      position: absolute;
-      right: 0px;
-      height: 40px;
-      margin-top: 10px;
-      border: solid 1px #f5f3f4;
-      background: #f5f3f4;
-    }
-    // .close-box {
-    //   width: 150px;
-    //   height: 60px;
-    //   padding-left: 8px;
-    //   margin-left: 8px;
-    //   line-height: 60px;
-    //   border: solid 1px rgba(29,161,242,1.00);
-    //   border-radius: 3px;
-    //   background: white;
-    //   a {
-    //     text-decoration: none;
-    //     color: black;
-    //   }
-    // }
+    right: 0px;
+    height: 40px;
+    margin-top: 10px;
+    border: solid 1px #f5f3f4;
+    background: #f5f3f4;
   }
 }

--- a/app/assets/stylesheets/posts/sp-index.scss
+++ b/app/assets/stylesheets/posts/sp-index.scss
@@ -15,10 +15,7 @@ h1.sp-top-home {
   .sp-list-box {
     display: block !important;
     width: 100%;
-    // height: 500px;
     background-color: white;
-    // overflow-y: scroll;
-    // border: 1px solid #f5f3f4;
     a {
       text-decoration: none;
       color: black;

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -21,3 +21,49 @@
     font-size: 18px;
   }
 }
+.sp-search {
+  display: none !important;
+}
+@media screen and (max-width: 500px) {
+  .search-result {
+    display: none !important;
+  }
+  .sp-search {
+    display: block !important;
+    text-align: center;
+    background: white;
+    #q_name_or_text_cont {
+      padding: 0 10px;
+      margin: 10px 5px;
+      height: 32px;
+      background: white;
+      border: 1px solid gray;
+    }
+    &__btn {
+      background: white;
+      border: 1px solid gray;
+      padding: 5px;
+    }
+    &__result {
+      font-weight: bold;
+      font-size: 18px;
+      text-align: center;
+      background: white;
+    }
+    &__text {
+      text-align: center;
+      background: white;
+    }
+    &__paginate {
+      padding:10px 0 70px 0;
+      text-align: center;
+      background: white;
+      a {
+        color: black;
+        text-decoration: none;
+        font-size: 16px;
+        padding: 0 5px 0 0;
+      }
+    }
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,11 @@ class ApplicationController < ActionController::Base
   end
 
   def search
-    @search = Post.ransack(search_params)
-    @search_result = @search.result.page(params[:page]).per(20)
+    if params[:q].present?
+      @search_result = @search.result.page(params[:page]).per(20)
+    else
+      render :search
+    end
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   def index
     @all_ranks = Post.create_all_ranks
-    @posts = Post.includes(:user).order('updated_at DESC')
+    @posts = Post.includes(:user, :likes, :comments).order('updated_at DESC')
     @users = User.all.order('updated_at DESC')
     @meals = Meal.order('updated_at DESC')
     if user_signed_in?
@@ -71,9 +71,6 @@ class PostsController < ApplicationController
 
   def ranking
     @all_ranks = Post.create_all_ranks
-    if user_signed_in?
-      @current_user_posts=Post.where(user_id:current_user.id).order('updated_at DESC')
-  end
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,10 +5,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag    'application', media: 'all' %>
     <meta content="width=device-width, initial=1.0" name="viewport"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application' %>
     <link href="https://use.fontawesome.com/releases/v5.7.0/css/all.css" rel="stylesheet">
   </head>
 

--- a/app/views/layouts/shared/_sp-banner.html.erb
+++ b/app/views/layouts/shared/_sp-banner.html.erb
@@ -8,5 +8,8 @@
     <%= link_to ranking_posts_path do %>
       <i class="fas fa-heart fa-3x"></i>
     <% end %>
+    <%= link_to search_posts_path do %>
+      <i class="fa fa-search fa-3x"></i>
+    <% end %>
   </div>
 </div>

--- a/app/views/layouts/shared/_sp-header.html.erb
+++ b/app/views/layouts/shared/_sp-header.html.erb
@@ -12,7 +12,7 @@
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class:'sidebar__user-link' %>
       <%= link_to 'プロフィール変更', edit_user_registration_path, class:'sidebar__user-link',data: {"turbolinks"=>false} %>
       <div class="sidebar__count">
-        登った山は<%= @current_user_posts.count %>ヶ所です！
+        登った山は<%= current_user.posts.count %>ヶ所です！
       </div>
       <%= render 'users/shared/stats' %>
       <%= link_to "登った山とメシを投稿", new_post_path, class:'sidebar__link-path',data: {"turbolinks"=>false} %>
@@ -23,19 +23,6 @@
       <%= link_to "新規登録", new_user_registration_path, class:'sidebar__link-path',data: {"turbolinks"=>false} %>
     <% end %>
   </aside>
-  <i class="fa fa-search fa-2x"></i>
-  <div class="modal js-modal">
-    <div class="modal__bg js-modal-close"></div>
-    <div class="modal__content">
-      <%= search_form_for @search, url:search_posts_path do |f| %>
-        <%= f.search_field :name_or_text_cont, class: 'modal__content__search-box', placeholder: '山の名前を検索' %>
-        <%= f.submit '検索', class:'modal__content__search-btn' %>
-      <% end %>
-      <div class="close-box">
-        <a class="js-modal-close" href="">閉じる</a>
-      </div>
-    </div>
-  </div>
   <%= link_to root_path, class:'logo-box' do %>
     <h1 class="logo-box__sp-logo">岳人</h1>
     <h3 class="logo-box__sp-kana">〜たけと〜</h3>

--- a/app/views/likes/_like-links.html.erb
+++ b/app/views/likes/_like-links.html.erb
@@ -1,14 +1,14 @@
 <% if user_signed_in? %>
   <div class="like-link" id="like-link-<%= post.id %>">
     <% if current_user.likes.find_by(post_id: post.id) %>
-      <%=link_to unlike_path(post.id), method: :delete, class:'like-button', remote: true do %>
+      <%=link_to unlike_path(post.id), method: :delete, class:'like-button', remote: true, data: {"turbolinks"=>true} do %>
         <div class="detail-like" id="heart-<%= post.id %>">
           <i class="fas fa-heart fa-2x"></i>
           <span><%= post.likes.count %></span>
         </div>
       <% end %>
     <% else %>
-      <%=link_to like_path(post.id), method: :post, class:'like-button', remote: true do %>
+      <%=link_to like_path(post.id), method: :post, class:'like-button', remote: true, data: {"turbolinks"=>true} do %>
         <div class="detail-like" id="heart-<%= post.id %>">
           <i class="far fa-heart fa-2x"></i>
           <span><%= post.likes.count %></span>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -28,6 +28,6 @@
   <div class="sp-list-box">
     <%= render partial: 'posts/partial/sp-index', collection: @posts, as: :post %>
   </div>
-  <%= render 'layouts/shared/sp-banner' %>
-  <%= render 'layouts/shared/footer' %><%# スマホ用バナー %>
+  <%= render 'layouts/shared/sp-banner' %><%# スマホ用バナー %>
+  <%= render 'layouts/shared/footer' %>
 </body>

--- a/app/views/posts/notification.html.erb
+++ b/app/views/posts/notification.html.erb
@@ -6,6 +6,18 @@
       <div class="detail-name">
         お知らせ
       </div>
+      <h2>2019.10.23</h2>
+      <div class="detail-description">
+        <div class="detail-display">
+          <li>検索ページをレスポンシブ化</li>
+        </div>
+      </div>
+      <h2>2019.10.22</h2>
+      <div class="detail-description">
+        <div class="detail-display">
+          <li>トップページをレスポンシブ化</li>
+        </div>
+      </div>
       <h2>2019.10.19</h2>
       <div class="detail-description">
         <div class="detail-display">

--- a/app/views/posts/partial/_sp-index.html.erb
+++ b/app/views/posts/partial/_sp-index.html.erb
@@ -1,4 +1,4 @@
-<%= link_to "posts/#{ post.id }" do %>
+<%= link_to post_path(post) do %>
   <div class="sp-post-box">
     <% if post.image.present? %>
       <%= image_tag post.image.url, class:"sp-post-box__picture"%>
@@ -16,5 +16,7 @@
 <% end %>
 <div class="sp-post-box__like">
   <%= render 'likes/like-links', post: post %>
-  <i class="far fa-comment fa-2x"><span><%= post.comments.count %></span></i>
+  <i class="far fa-comment fa-2x">
+    <span><%= post.comments.count %></span>
+  </i>
 </div>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -1,20 +1,48 @@
 <body>
   <%= render "layouts/shared/header" %>
-  <div class="search-result">
-    <h2 class="search-result__title">"<%= @search.name_or_text_cont %>"の検索結果{ <%= @search_result.total_count %>件 }</h2>
-    <% if @search_result.present? %>
-      <div class="search-result__count">
-        <%= @search_result.current_page %>/<%= @search_result.total_pages %>ページ
-      </div>
-      <div class="search-container">
-        <%= render partial: 'posts/partial/yama-lists', collection: @search_result, as:'post'%>
-      </div>
-      <%= paginate @search_result %>
-    <% else %>
-  </div>
+  <% if @search_result.present? %>
+    <div class="search-result">
+      <h2 class="search-result__title">"<%= @search.name_or_text_cont %>"の検索結果{ <%= @search_result.total_count %>件 }</h2>
+        <div class="search-result__count">
+          <%= @search_result.current_page %>/<%= @search_result.total_pages %>ページ
+        </div>
+        <div class="search-container">
+          <%= render partial: 'posts/partial/yama-lists', collection: @search_result, as:'post'%>
+        </div>
+        <%= paginate @search_result %>
+    </div>
+  <% else %>
     <div class="search-result">
       <h2 class="search-result__title">該当する投稿が見つかりません。</h2>
     </div>
   <% end %>
   <%= render "layouts/shared/footer" %>
 </body>
+
+<%# スマホ用searchページ %>
+<%= render "layouts/shared/sp-header" %>
+<div class="sp-search">
+  <%= search_form_for @search, url:search_posts_path do |f| %>
+    <%= f.search_field :name_or_text_cont, class: 'sp-search__box', placeholder: '山の名前を検索' %>
+    <%= f.submit '検索', class:'sp-search__btn' %>
+  <% end %>
+</div>
+<% if @search_result.present? %>
+  <h2 class="sp-search__result">
+    <%= @search.name_or_text_cont %>"の検索結果{ <%= @search_result.total_count %>件 }
+  </h2>
+  <h3 class="sp-search__text">
+    <%= @search_result.current_page %>/<%= @search_result.total_pages %>ページ
+  </h3>
+  <div class="sp-list-box">
+    <%= render partial: 'posts/partial/sp-index', collection: @search_result, as: :post %>
+  </div>
+  <div class="sp-search__paginate">
+    <%= paginate @search_result %>
+  </div>
+<% elsif @search_result == [] %>
+  <h2 class="sp-search__result">該当する投稿が見つかりません。</h2>
+<% else %>
+    <h2 class="sp-search__result">キーワードを入力して下さい</h2>
+<% end %>
+<%= render 'layouts/shared/sp-banner' %>


### PR DESCRIPTION
## WHAT

- スマホ用searchページ作成。
- turbolinks削除。
- 
## WHY

- モーダルの検索窓だと使いにくかったので検索アイコンを設置し別ページに設置する事でユーザビリティを向上できると思った為。
topページで使うjsがturnolinksがあるとイベント発火しない為。

## IMAGE

![スクリーンショット 2019-10-23 19 07 45](https://user-images.githubusercontent.com/51276845/67382702-e4a82580-f5c8-11e9-841c-71999bb08749.png)
