### PR TITLE
ユーザー一覧ページ作成

### DIFF
--- a/app/assets/stylesheets/posts/sp-index.scss
+++ b/app/assets/stylesheets/posts/sp-index.scss
@@ -5,8 +5,9 @@ h1.sp-top-home,.sp-list-box,.sp-main {
   .sp-main {
     display: block !important;
     margin-bottom: 70px;
+    background: white;
   }
-  h1.sp-top-home {
+  h1.sp-top-home,h2.sp-top-follow {
     display: block !important;
     font-size: 20px;
     background: white;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,14 +8,14 @@ class UsersController < ApplicationController
   def following
     @title = "フォロー 一覧"
     @user  = User.find(params[:id])
-    @users = @user.following.page(params[:page]).per(5)
+    @users = @user.following.page(params[:page]).per(10)
     render 'show-follow'
   end
 
   def followers
     @title = "フォロワー 一覧"
     @user  = User.find(params[:id])
-    @users = @user.followers.page(params[:page]).per(5)
+    @users = @user.followers.page(params[:page]).per(10)
     render 'show-follow'
   end
 end

--- a/app/views/layouts/shared/_sp-banner.html.erb
+++ b/app/views/layouts/shared/_sp-banner.html.erb
@@ -6,7 +6,10 @@
     <%= link_to meals_path do %>
       <i class="fas fa-hamburger fa-3x"></i>
     <% end %>
-    <i class="fas fa-users fa-3x"></i>
+    <% @user ||= current_user %>
+      <%= link_to following_user_path(@user) do %>
+        <i class="fas fa-users fa-3x"></i>
+      <% end %>
     <%= link_to rankings_path do %>
       <i class="fas fa-heart fa-3x"></i>
     <% end %>

--- a/app/views/users/show-follow.html.erb
+++ b/app/views/users/show-follow.html.erb
@@ -1,29 +1,60 @@
 <% provide(:title, @title) %>
 <body>
 <%= render 'layouts/shared/header' %>
-  <div class="follow-list">
-    <div class="follow-list__container">
-      <%= render 'users/shared/stats' %>
-      <div class="follow-list__title"><%= @title %></div>
-      <% if @users.any? %>
-        <% @users.each do |user| %>
-          <div class="follow-user">
-            <%= link_to user, class:'follow-user__link' do %>
-              <% if user.image.present? %>
-                <%= image_tag user.image.url, class:"follow-user__picture" %>
-              <% else %>
-                <img class="follow-user__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+  <main>
+    <div class="follow-list">
+      <div class="follow-list__container">
+        <%= render 'users/shared/stats' %>
+        <div class="follow-list__title"><%= @title %></div>
+        <% if @users.any? %>
+          <% @users.each do |user| %>
+            <div class="follow-user">
+              <%= link_to user, class:'follow-user__link' do %>
+                <% if user.image.present? %>
+                  <%= image_tag user.image.url, class:"follow-user__picture" %>
+                <% else %>
+                  <img class="follow-user__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+                <% end %>
+                <div class="follow-user__nickname"><%= user.nickname %></div>
               <% end %>
-              <div class="follow-user__nickname"><%= user.nickname %></div>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
+          <div class="follow-list__paginate"><%= paginate @users %></div>
         <% end %>
-        <div class="follow-list__paginate"><%= paginate @users %></div>
-      <% end %>
-      <div class="follow-list__btn">
-        <%= link_to "ホーム", root_path, class:'follow-list__btn__gray' %>
+        <div class="follow-list__btn">
+          <%= link_to "ホーム", root_path, class:'follow-list__btn__gray' %>
+        </div>
       </div>
     </div>
-  </div>
+  </main>
 <%= render 'layouts/shared/footer' %>
 </body>
+<%# スマホ用フォロー一覧ページ %>
+<%= render 'layouts/shared/sp-header' %>
+<h1 class="sp-top-home"><%= @title %></h1>
+<div class="sp-main">
+  <%= render 'users/shared/stats' %>
+  <% if @users.any? %>
+    <% @users.each do |user| %>
+      <div class="sp-list-box">
+        <%= link_to user do %>
+          <div class="sp-post-box">
+            <% if user.image.present? %>
+              <%= image_tag user.image.url, class:"sp-post-box__picture" %>
+            <% else %>
+              <img class="sp-post-box__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+            <% end %>
+            <div class="sp-post-box__description">
+              <%= user.nickname %>
+              <div class="sp-post-box__description__comment">
+                <label><%= user.profile %><label>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="follow-list__paginate"><%= paginate @users %></div>
+  <% end %>
+</div>
+<%= render 'layouts/shared/sp-banner' %>


### PR DESCRIPTION
## WHAT

- ユーザーフォロー/フォロワーの一覧ページを作成。

## WHY

- スマホサイズ用にする事でユーザビリティが向上すると考えた為。

## IMAGE

![スクリーンショット 2019-10-24 16 07 27](https://user-images.githubusercontent.com/51276845/67461575-9e120400-f678-11e9-814f-df923a5c6e65.png)
