### PR TITLE
スマホ用posts#showページ作成

### DIFF
--- a/app/assets/stylesheets/posts/show.scss
+++ b/app/assets/stylesheets/posts/show.scss
@@ -99,3 +99,61 @@
     }
   }
 }
+.sp-detail {
+  display: none !important;
+}
+@media screen and (max-width: 500px) {
+  .sp-detail {
+    display: block !important;
+    &__user {
+      display: flex;
+      &__picture {
+        width: 50px;
+        height: auto;
+        max-height: 50px;
+        border-radius: 50%;
+        margin: 10px 15px;
+      }
+      &__nickname {
+        margin: 23px 0 0 0;
+        font-size: 18px;
+      }
+    }
+    &__pic-box {
+      &__picture {
+        width: 100%;
+        height: auto;
+      }
+    }
+    .far.fa-heart {
+      color: gray;
+      margin: 5px 10px;
+    }
+    .far.fa-comment {
+      color: gray;
+    }
+    &__title {
+      text-align: center;
+      font-size: 21px;
+      font-weight: bold;
+    }
+    &__description {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      &__name {
+        margin: 10px 15px;
+      }
+      &__count {
+        font-size: 18px;
+        font-weight: bold;
+      }
+    }
+    &__comment {
+      width: 100%;
+      text-align: center;
+      margin: 10px 0;
+      word-break: break-all;
+    }
+  }
+}

--- a/app/views/layouts/shared/_sp-banner.html.erb
+++ b/app/views/layouts/shared/_sp-banner.html.erb
@@ -7,10 +7,13 @@
       <i class="fas fa-hamburger fa-3x"></i>
     <% end %>
     <% if user_signed_in? %>
-      <% @user ||= current_user %>
-        <%= link_to following_user_path(@user) do %>
-          <i class="fas fa-users fa-3x"></i>
-        <% end %>
+      <%= link_to following_user_path(@user) do %>
+        <i class="fas fa-users fa-3x"></i>
+      <% end %>
+    <% else %>
+      <%= link_to new_user_session_path  do %>
+        <i class="fas fa-user fa-3x"></i>
+      <% end %>
     <% end %>
     <%= link_to rankings_path do %>
       <i class="fas fa-heart fa-3x"></i>
@@ -19,9 +22,4 @@
       <i class="fa fa-search fa-3x"></i>
     <% end %>
   </div>
-  <% if user_signed_in? %>
-    <%=link_to new_post_path, class:'sp-footer-btn' do %>
-      <i class="far fa-paper-plane fa-3x"></i>
-    <% end %>
-  <% end %>
 </div>

--- a/app/views/layouts/shared/_sp-button.html.erb
+++ b/app/views/layouts/shared/_sp-button.html.erb
@@ -1,0 +1,5 @@
+<% if user_signed_in? %>
+  <%=link_to new_post_path, class:'sp-footer-btn' do %>
+    <i class="far fa-paper-plane fa-3x"></i>
+  <% end %>
+<% end %>

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -22,4 +22,5 @@
     </div>
   <% end %>
 </div>
+<%= render 'layouts/shared/sp-button' %>
 <%= render 'layouts/shared/sp-banner' %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,6 +32,7 @@
     </div>
   </div>
   <%# スマホ用バナー %>
+  <%= render 'layouts/shared/sp-button' %>
   <%= render 'layouts/shared/sp-banner' %>
   <%= render 'layouts/shared/footer' %>
 </body>

--- a/app/views/posts/partial/_sp-index.html.erb
+++ b/app/views/posts/partial/_sp-index.html.erb
@@ -16,7 +16,9 @@
 <% end %>
 <div class="sp-post-box__like">
   <%= render 'likes/like-links', post: post %>
-  <i class="far fa-comment fa-2x">
-    <span><%= post.comments.count %></span>
-  </i>
+  <%= link_to post_path(post) do %>
+    <i class="far fa-comment fa-2x">
+      <span><%= post.comments.count %></span>
+    </i>
+  <% end %>
 </div>

--- a/app/views/posts/search.html.erb
+++ b/app/views/posts/search.html.erb
@@ -45,4 +45,5 @@
 <% else %>
     <h2 class="sp-search__result">キーワードを入力して下さい</h2>
 <% end %>
+<%= render 'layouts/shared/sp-button' %>
 <%= render 'layouts/shared/sp-banner' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,57 +1,109 @@
 <body>
 <%= render "layouts/shared/header" %>
-  <div class="detail-post-box">
-    <div class="user-info">
-      <% if @post.user.image.present? %>
-        <%= image_tag @post.user.image.url, class:'user-info__face' %>
-      <% else %>
-        <img class="user-info__face" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
-      <% end %>
-      <div class="user-info__name">
-        <%= @post.user.nickname %>
+  <main>
+    <div class="detail-post-box">
+      <div class="user-info">
+        <% if @post.user.image.present? %>
+          <%= image_tag @post.user.image.url, class:'user-info__face' %>
+        <% else %>
+          <img class="user-info__face" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+        <% end %>
+        <div class="user-info__name">
+          <%= @post.user.nickname %>
+        </div>
+      </div>
+      <div class="detail-container">
+        <div class="detail-container__name">
+          <%= @post.name %>
+          <%= render 'likes/like-links', post: @post %>
+        </div>
+        <% if @post.image.present? %>
+          <%= image_tag @post.image.url, class:'detail-container__picture' %>
+        <% else %>
+          <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="detail-container__picture">
+        <% end %>
+        <h2>山の詳細データ</h2>
+        <div class="detail-description">
+          <div class="detail-description__display">
+            山頂標高:<%= @post.elevation %>M
+          </div>
+          <div class="detail-description__display">
+            歩行距離:<%= @post.walking_distance %>KM
+          </div>
+          <div class="detail-description__display">
+            <%= @post.difficulty_i18n %>
+          </div>
+        </div>
+        <h2><%= @post.user.nickname %>さんのコメント</h2>
+        <div class="detail-comment">
+          <%= simple_format(@post.text) %>
+        </div>
+
+        <%= render 'comments/comment' %>
+
+        <% if user_signed_in? && current_user.id == @post.user_id %>
+          <div class="detail-btn">
+            <%= link_to 'ホーム', root_path, class:'detail-btn__gray' %>
+            <%= link_to '編集', edit_post_path(@post), method: :get, class:'detail-btn__gray' %>
+            <%= link_to '削除する', post_path(@post), method: :delete, class:'detail-btn__red', data: { confirm: "本当に削除しますか?" } %>
+          </div>
+        <% else %>
+          <div class="detail-btn">
+            <%= link_to 'ホーム', root_path, class:'detail-btn__gray' %>
+          </div>
+        <% end %>
       </div>
     </div>
-    <div class="detail-container">
-      <div class="detail-container__name">
-        <%= @post.name %>
-        <%= render 'likes/like-links', post: @post %>
-      </div>
-      <% if @post.image.present? %>
-        <%= image_tag @post.image.url, class:'detail-container__picture' %>
-      <% else %>
-        <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="detail-container__picture">
-      <% end %>
-      <h2>山の詳細データ</h2>
-      <div class="detail-description">
-        <div class="detail-description__display">
-          山頂標高:<%= @post.elevation %>M
-        </div>
-        <div class="detail-description__display">
-          歩行距離:<%= @post.walking_distance %>KM
-        </div>
-        <div class="detail-description__display">
-          <%= @post.difficulty_i18n %>
-        </div>
-      </div>
-      <h2><%= @post.user.nickname %>さんのコメント</h2>
-      <div class="detail-comment">
-        <%= simple_format(@post.text) %>
-      </div>
-
-      <%= render 'comments/comment' %>
-
-      <% if user_signed_in? && current_user.id == @post.user_id %>
-        <div class="detail-btn">
-          <%= link_to 'ホーム', root_path, class:'detail-btn__gray' %>
-          <%= link_to '編集', edit_post_path(@post), method: :get, class:'detail-btn__gray' %>
-          <%= link_to '削除する', post_path(@post), method: :delete, class:'detail-btn__red', data: { confirm: "本当に削除しますか?" } %>
-        </div>
-      <% else %>
-        <div class="detail-btn">
-          <%= link_to 'ホーム', root_path, class:'detail-btn__gray' %>
-        </div>
-      <% end %>
-    </div>
-  </div>
+  </main>
 <%= render 'layouts/shared/footer' %>
 </body>
+<%# スマホ用詳細ページ %>
+<%= render 'layouts/shared/sp-header' %>
+<div class="sp-main">
+  <div class="sp-detail">
+    <div class="sp-detail__user">
+      <% if @post.user.image.present? %>
+        <%= image_tag @post.user.image.url, class:'sp-detail__user__picture' %>
+      <% else %>
+        <img class="sp-detail__user__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+      <% end %>
+      <div class="sp-detail__user__nickname"><%= @post.user.nickname %></div>
+    </div>
+    <div class="sp-detail__pic-box">
+      <% if @post.image.present? %>
+        <%= image_tag @post.image.url, class:'sp-detail__pic-box__picture' %>
+      <% else %>
+        <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="sp-detail__pic-box__picture">
+      <% end %>
+    </div>
+    <i class="far fa-heart fa-2x">
+      <span><%= @post.likes.count %></span>
+    </i>
+    <i class="far fa-comment fa-2x">
+      <span><%= @post.comments.count %></span>
+    </i>
+    <h2 class='sp-detail__title'>山のデータ</h2>
+    <div class='sp-detail__description'>
+      <div class='sp-detail__description__name'>
+        山頂標高:
+        <div class='sp-detail__description__count'>
+          <%= @post.elevation %>M
+        </div>
+      </div>
+      <div class='sp-detail__description__name'>
+        歩行距離:
+        <div class='sp-detail__description__count'>
+          <%= @post.walking_distance %>KM
+        </div>
+      </div>
+      <div class='sp-detail__description__name'>
+        <%= @post.difficulty_i18n %>
+      </div>
+    </div>
+    <h2 class='sp-detail__title'>一言コメント</h2>
+      <div class='sp-detail__comment'>
+      <%= simple_format(@post.text) %>
+    </div>
+  </div>
+</div>
+<%= render "layouts/shared/sp-banner" %>

--- a/app/views/rankings/index.html.erb
+++ b/app/views/rankings/index.html.erb
@@ -31,4 +31,5 @@
     <% end %>
   </div>
 </div>
+<%= render 'layouts/shared/sp-button' %>
 <%= render 'layouts/shared/sp-banner' %>

--- a/app/views/users/show-follow.html.erb
+++ b/app/views/users/show-follow.html.erb
@@ -57,4 +57,5 @@
     <div class="follow-list__paginate"><%= paginate @users %></div>
   <% end %>
 </div>
+<%= render 'layouts/shared/sp-button' %>
 <%= render 'layouts/shared/sp-banner' %>


### PR DESCRIPTION
 ## WHAT

- スマホ用posts#showページの作成。
- 投稿ボタンは詳細ページでは非表示にする為にファイルに切り出し。

## WHY

- デバイスフレンドリーのレイアウトに修正し、スマホからのアクセスでも詳細ページが適切に表示されるようにする為。
- 詳細ページのレイアウト上に投稿ボタンがあると、レイアウトの邪魔になってしまう為。

## IMAGE

![スクリーンショット 2019-10-26 22 48 57](https://user-images.githubusercontent.com/51276845/67620513-dc5b1f00-f842-11e9-916d-32bc59fa7ab2.png)

## 備考

- いいね・コメントアイコンは仮置き。