### PR TITLE
ユーザー詳細ページ作成

### DIFF
--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -10,3 +10,29 @@
     }
   }
 }
+@media screen and (max-width: 500px) {
+  .sp-detail {
+    &__user {
+      &__follow_form {
+        margin: 12px 0 0 25px;
+        .following-btn, .followed-btn {
+          width: 90px;
+          height: 30px;
+          background: white;
+          color: #2AD1FF;
+          border: solid 1px #2AD1FF;
+          border-radius: 25px;
+          padding: 3px;
+          margin-top: 10px;
+        }
+        .followed-btn {
+          background: #2AD1FF;
+          color: white;
+        }
+      }
+    }
+  }
+  .sp-posts-count {
+    margin: 0 0 0 10px;
+  }
+}

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,4 +1,4 @@
-<%= form_for(current_user.active_relationships.build, remote: true) do |f| %>
+<%= form_for(current_user.active_relationships.build) do |f| %>
   <div><%= hidden_field_tag :followed_id, @user.id %></div>
   <%= f.submit "フォローする", class: "following-btn" %>
 <% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,4 +1,4 @@
 <%= form_for(current_user.active_relationships.find_by(followed_id: @user.id),
-             html: { method: :delete }, remote: true) do |f| %>
+             html: { method: :delete }) do |f| %>
   <%= f.submit "フォロー中", class: "followed-btn" %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,14 +11,12 @@
           <img class="sp-post-box__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
         <% end %>
         <div class="sp-post-box__description">
-          <% if user_signed_in? %>
-            <% if current_user != user %>
-              <div id="follow_form">
-                <% if current_user.following?(user) %>
-                  <div class='followed-btn'>フォロー中</div>
-                <% end %>
-              </div>
-            <% end %>
+          <% if user_signed_in? && current_user != user %>
+            <div id="follow_form">
+              <% if current_user.following?(user) %>
+                <div class='followed-btn'>フォロー中</div>
+              <% end %>
+            </div>
           <% end %>
           <%= user.nickname %>
           <div class="sp-post-box__description__comment">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
-<body>
-  <%= render 'layouts/shared/header' %>
+<%= render 'layouts/shared/header' %>
+  <main>
     <div class="detail-post-box">
       <div class="detail-user-container">
         <div class="detail-picture">
@@ -36,5 +36,36 @@
         </div>
       </div>
     </div>
-  <%= render 'layouts/shared/footer' %>
-</body>
+  </main>
+<%= render 'layouts/shared/footer' %>
+
+<%# スマホ用ページ %>
+<%= render 'layouts/shared/sp-header' %>
+<div class='sp-main'>
+  <div class='sp-detail'>
+    <div class='sp-detail__user'>
+      <% if @user.image.present? %>
+        <%= image_tag @user.image.url, class:'sp-detail__user__picture' %>
+      <% else %>
+        <img class='sp-detail__user__picture' src='https://static.mercdn.net/images/member_photo_noimage_thumb.png'>
+      <% end %>
+      <div class='sp-detail__user__nickname'><%= @user.nickname %></div>
+      <div class='sp-detail__user__follow_form'>
+        <%= render 'follow_form' if user_signed_in? %>
+      </div>
+    </div>
+    <%= render 'users/shared/stats' %>
+    <div class='sp-detail__comment'>
+      <%= simple_format(@user.profile) %>
+    </div>
+  </div>
+  <% if @user.posts.any? %>
+    <h2 class='sp-posts-count'>投稿一覧 (<%= @user.posts.count %>)</h2>
+    <div class="sp-list-box">
+      <%= render partial: 'posts/partial/sp-index', collection: @posts, as:'post'%>
+    </div>
+  <% else %>
+    <h2 class='sp-posts-count'>まだ投稿はありません</h2>
+  <% end %>
+</div>
+<%= render 'layouts/shared/sp-banner' %>


### PR DESCRIPTION
## WHAT

- スマホ用のユーザー詳細ページの作成。

## WHY

- スマホからアクセスしてもレイアウトが崩れないようにし、ユーザビリティを向上させる為。

## IMAGE

![スクリーンショット 2019-10-29 16 31 18](https://user-images.githubusercontent.com/51276845/67746376-b6639380-fa69-11e9-82fa-723db0d298d8.png)


## 備考

- フォロー機能のajax一時的に解除。PC/スマホ両方で利用できるようにする為。