### PR TITLE
サインアップページ作成

### DIFF
--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -221,7 +221,7 @@ input[type=number]::-webkit-outer-spin-button {
       border-radius: 3px;
     }
     .file-field {
-      margin: 10px 0 0 0;
+      margin: 10px 0 0 20px;
     }
   }
 }

--- a/app/assets/stylesheets/posts/show.scss
+++ b/app/assets/stylesheets/posts/show.scss
@@ -124,6 +124,16 @@
       font-size: 21px;
       font-weight: bold;
       margin: 0 0 10px 0;
+      position: relative;
+    }
+    &__btn {
+      color: gray;
+      .far.fa-edit {
+        margin-left: 10px;
+      }
+      .far.fa-trash-alt {
+        margin-left: 20px;
+      }
     }
     &__pic-box {
       &__picture {

--- a/app/views/devise/partial/_signup.html.erb
+++ b/app/views/devise/partial/_signup.html.erb
@@ -1,0 +1,52 @@
+<div class="new-post-box__container__name">
+  新規会員登録
+</div>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="form-registration-box">
+    <%= f.label :email, class:'form-registration-box__name' %>
+  </div>
+  <%= f.email_field :email, autofocus: true, placeholder: 'メールアドレスを入力', class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :nickname, class:'form-registration-box__name' %>
+  </div>
+  <%= f.text_field :nickname, placeholder: 'ニックネームを入力', maxlength:20, class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :profile, class:'form-registration-box__name' %>
+  </div>
+  <%= f.text_area :profile, placeholder: '自己紹介しよう！', class:'new-part-form', id:'textarea' %>
+
+  <div class="form-registration-box">
+    <%= f.label :password, class:'form-registration-box__name' %>
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> 文字以上)</em>
+    <% end %>
+  </div>
+  <%= f.password_field :password, placeholder: 'パスワードを入力', autocomplete: "new-password", class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :password_confirmation, class:'form-registration-box__name' %>
+  </div>
+  <%= f.password_field :password_confirmation, placeholder: 'パスワードをもう一度入力', autocomplete: "new-password", class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :プロフィール画像, class:'form-registration-box__name' %>
+  </div>
+  <div class="photo-form">
+    <div class="form-mask">
+      <%= f.label :image, class:'form-mask-image' do %>
+        <%= f.file_field :image, class:'hidden' %>
+        <div class="form-mask-image">プロフィール画像をアップロード</div>
+        <i class="far fa-image fa-3x"></i>
+      <% end %>
+    </div>
+  </div>
+  <div class="preview"></div>
+
+  <%= f.submit "登録する", class:'new-post-box__btn' %>
+<% end %>
+既にアカウントをお持ちですか？
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/partial/_sp-signup.html.erb
+++ b/app/views/devise/partial/_sp-signup.html.erb
@@ -1,0 +1,43 @@
+<div class="new-post-box__container__name">
+  新規会員登録
+</div>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="form-registration-box">
+    <%= f.label :email, class:'form-registration-box__name' %>
+  </div>
+  <%= f.email_field :email, autofocus: true, placeholder: 'メールアドレスを入力', class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :nickname, class:'form-registration-box__name' %>
+  </div>
+  <%= f.text_field :nickname, placeholder: 'ニックネームを入力', maxlength:20, class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :profile, class:'form-registration-box__name' %>
+  </div>
+  <%= f.text_area :profile, placeholder: '自己紹介しよう！', class:'new-part-form', id:'textarea' %>
+
+  <div class="form-registration-box">
+    <%= f.label :password, class:'form-registration-box__name' %>
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> 文字以上)</em>
+    <% end %>
+  </div>
+  <%= f.password_field :password, placeholder: 'パスワードを入力', autocomplete: "new-password", class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :password_confirmation, class:'form-registration-box__name' %>
+  </div>
+  <%= f.password_field :password_confirmation, placeholder: 'パスワードをもう一度入力', autocomplete: "new-password", class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :プロフィール画像, class:'form-registration-box__name' %>
+  </div>
+  <%= f.file_field :image, class:'file-field' %>
+
+  <%= f.submit "登録する", class:'new-post-box__btn' %>
+<% end %>
+既にアカウントをお持ちですか？
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,60 +1,17 @@
-<body>
-  <%= render 'layouts/shared/header' %>
-    <div class="new-post-box">
-      <div class="new-post-box__container">
-        <div class="new-post-box__container__name">
-          新規会員登録
-        </div>
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-          <%= render "devise/shared/error_messages", resource: resource %>
-
-          <div class="form-registration-box">
-            <%= f.label :email, class:'form-registration-box__name' %>
-          </div>
-          <%= f.email_field :email, autofocus: true, placeholder: 'メールアドレスを入力', class:'new-part-form' %>
-
-          <div class="form-registration-box">
-            <%= f.label :nickname, class:'form-registration-box__name' %>
-          </div>
-          <%= f.text_field :nickname, placeholder: 'ニックネームを入力', maxlength:20, class:'new-part-form' %>
-
-          <div class="form-registration-box">
-            <%= f.label :profile, class:'form-registration-box__name' %>
-          </div>
-          <%= f.text_area :profile, placeholder: '自己紹介しよう！', class:'new-part-form', id:'textarea' %>
-
-          <div class="form-registration-box">
-            <%= f.label :password, class:'form-registration-box__name' %>
-            <% if @minimum_password_length %>
-              <em>(<%= @minimum_password_length %> 文字以上)</em>
-            <% end %>
-          </div>
-          <%= f.password_field :password, placeholder: 'パスワードを入力', autocomplete: "new-password", class:'new-part-form' %>
-
-          <div class="form-registration-box">
-            <%= f.label :password_confirmation, class:'form-registration-box__name' %>
-          </div>
-          <%= f.password_field :password_confirmation, placeholder: 'パスワードをもう一度入力', autocomplete: "new-password", class:'new-part-form' %>
-
-          <div class="form-registration-box">
-            <%= f.label :プロフィール画像, class:'form-registration-box__name' %>
-          </div>
-          <div class="photo-form">
-            <div class="form-mask">
-              <%= f.label :image, class:'form-mask-image' do %>
-                <%= f.file_field :image, class:'hidden' %>
-                <div class="form-mask-image">プロフィール画像をアップロード</div>
-                <i class="far fa-image fa-3x"></i>
-              <% end %>
-            </div>
-          </div>
-          <div class="preview"></div>
-
-          <%= f.submit "登録する", class:'new-post-box__btn' %>
-        <% end %>
-        既にアカウントをお持ちですか？
-        <%= render 'devise/shared/links' %>
-      </div>
+<%= render 'layouts/shared/header' %>
+<main>
+  <div class="new-post-box">
+    <div class="new-post-box__container">
+      <%= render 'devise/partial/signup' %>
     </div>
-  <%= render 'layouts/shared/footer' %>
-</body>
+  </div>
+</main>
+<%= render 'layouts/shared/footer' %>
+
+<%= render 'layouts/shared/sp-header' %>
+<div class='sp-main'>
+  <div class='sp-new-box'>
+  <%= render 'devise/partial/sp-signup' %>
+  </div>
+</div>
+<%= render 'layouts/shared/sp-banner' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -86,6 +86,14 @@
     <i class="far fa-comment fa-2x">
       <span><%= @post.comments.count %></span>
     </i>
+    <% if user_signed_in? && current_user.id == @post.user_id %>
+      <%= link_to edit_post_path(@post), method: :get, class:'sp-detail__btn' do %>
+        <i class="far fa-edit fa-2x"></i>
+      <% end %>
+      <%= link_to post_path(@post), method: :delete, class:'sp-detail__btn', data: { confirm: "本当に削除しますか?" } do %>
+        <i class="far fa-trash-alt fa-2x"></i>
+      <% end %>
+    <% end %>
     <h2 class='sp-detail__title'>山のデータ</h2>
     <div class='sp-detail__description'>
       <div class='sp-detail__description__name'>


### PR DESCRIPTION
## WHAT

- スマホ用サインアップページの作成。

## WHY

- デバイスフレンドリーなレイアウトに修正しスマホからでもレイアウトが崩れないようにする為。

## IMAGE

![スクリーンショット 2019-10-29 19 02 24](https://user-images.githubusercontent.com/51276845/67757219-ba4de080-fa7e-11e9-9707-30fa1ca1e836.png)
