### PR TITLE
ユーザーログインページ作成

### DIFF
--- a/app/assets/stylesheets/modules/_new.scss
+++ b/app/assets/stylesheets/modules/_new.scss
@@ -221,7 +221,7 @@ input[type=number]::-webkit-outer-spin-button {
       border-radius: 3px;
     }
     .file-field {
-      margin: 10px 0 0 30px;
+      margin: 10px 0 0 40px;
     }
   }
 }

--- a/app/views/devise/partial/_login.html.erb
+++ b/app/views/devise/partial/_login.html.erb
@@ -1,0 +1,24 @@
+<div class="new-post-box__container__name">
+  ログイン
+</div>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="form-registration-box">
+    <%= f.label :email, class:'form-registration-box__name' %>
+  </div>
+  <%= f.email_field :email, autofocus: true, autocomplete: "email",value: 'user1@example.com', class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :password, class:'form-registration-box__name' %>
+  </div>
+  <%= f.password_field :password, autocomplete: "current-password",value: 'password', class:'new-part-form' %>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="form-registration-box">
+      <%= f.check_box :remember_me %>
+      <%= f.label :パスワードを記憶する %>
+    </div>
+  <% end %>
+
+    <%= f.submit "ログイン", class:'new-post-box__btn' %>
+<% end %>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/partial/_sp-login.html.erb
+++ b/app/views/devise/partial/_sp-login.html.erb
@@ -1,0 +1,24 @@
+<div class="new-post-box__container__name">
+  ログイン
+</div>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="form-registration-box">
+    <%= f.label :email, class:'form-registration-box__name' %>
+  </div>
+  <%= f.email_field :email, autofocus: true, autocomplete: "email",value: 'user1@example.com', class:'new-part-form' %>
+
+  <div class="form-registration-box">
+    <%= f.label :password, class:'form-registration-box__name' %>
+  </div>
+  <%= f.password_field :password, autocomplete: "current-password",value: 'password', class:'new-part-form' %>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="form-registration-box">
+      <%= f.check_box :remember_me %>
+      <%= f.label :パスワードを記憶する %>
+    </div>
+  <% end %>
+
+    <%= f.submit "ログイン", class:'new-post-box__btn' %>
+<% end %>
+<%= render 'devise/shared/links' %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,32 +1,17 @@
-<body>
-  <%= render 'layouts/shared/header' %>
+<%= render 'layouts/shared/header' %>
+<main>
   <div class="new-post-box">
     <div class="new-post-box__container">
-      <div class="new-post-box__container__name">
-        ログイン
-      </div>
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <div class="form-registration-box">
-          <%= f.label :email, class:'form-registration-box__name' %>
-        </div>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email",value: 'user1@example.com', class:'new-part-form' %>
-
-        <div class="form-registration-box">
-          <%= f.label :password, class:'form-registration-box__name' %>
-        </div>
-        <%= f.password_field :password, autocomplete: "current-password",value: 'password', class:'new-part-form' %>
-
-        <% if devise_mapping.rememberable? %>
-          <div class="form-registration-box">
-            <%= f.check_box :remember_me %>
-            <%= f.label :パスワードを記憶する %>
-          </div>
-        <% end %>
-
-          <%= f.submit "ログイン", class:'new-post-box__btn' %>
-      <% end %>
-      <%= render 'devise/shared/links' %>
+      <%= render 'devise/partial/login' %>
     </div>
   </div>
-  <%= render 'layouts/shared/footer' %>
-</body>
+</main>
+<%= render 'layouts/shared/footer' %>
+
+<%= render 'layouts/shared/sp-header' %>
+<div class='sp-main'>
+  <div class='sp-new-box'>
+    <%= render 'devise/partial/sp-login' %>
+  </div>
+</div>
+<%= render 'layouts/shared/sp-banner' %>

--- a/app/views/posts/notification.html.erb
+++ b/app/views/posts/notification.html.erb
@@ -6,6 +6,21 @@
       <div class="detail-name">
         お知らせ
       </div>
+      <h2>2019.10.29</h2>
+      <div class="detail-description">
+        <div class="detail-display">
+          <li>サインアップページをレスポンシブ化</li>
+          <li>サインインページをレスポンシブ化</li>
+          <li>ユーザー一覧ページをレスポンシブ化</li>
+          <li>ユーザー詳細ページをレスポンシブ化</li>
+        </div>
+      </div>
+      <h2>2019.10.26</h2>
+      <div class="detail-description">
+        <div class="detail-display">
+          <li>投稿詳細ページをレスポンシブ化</li>
+        </div>
+      </div>
       <h2>2019.10.24</h2>
       <div class="detail-description">
         <div class="detail-display">


### PR DESCRIPTION
## WHAT

- スマホ用ユーザーログインページの作成。

## WHY

- デバイスフレンドリーなレイアウトに修正しスマホからでもレイアウトが崩れないようにする為。

## IMAGE

![スクリーンショット 2019-10-29 19 41 34](https://user-images.githubusercontent.com/51276845/67760217-40b8f100-fa84-11e9-806e-06b93320abcb.png)
