### PR TITLE
コメントビューの作成

### DIFF
--- a/app/assets/stylesheets/modules/_comment.scss
+++ b/app/assets/stylesheets/modules/_comment.scss
@@ -24,3 +24,17 @@
     }
   }
 }
+.sp-new-comment-box {
+  text-align: center;
+  &__form {
+    width: 300px;
+    margin: 10px 0;
+    border: 1px solid gray;
+    border-radius: 3px;
+  }
+  &__btn {
+    background: white;
+    border: 1px solid gray;
+    border-radius: 3px;
+  }
+}

--- a/app/assets/stylesheets/posts/show.scss
+++ b/app/assets/stylesheets/posts/show.scss
@@ -114,9 +114,20 @@
         border-radius: 50%;
         margin: 10px 15px;
       }
+      &__comment-picture {
+        width: 30px;
+        height: auto;
+        min-height: 30px;
+        max-height: 30px;
+        border-radius: 50%;
+        margin: 5px 10px;
+      }
       &__nickname {
         margin: 23px 0 0 0;
         font-size: 18px;
+      }
+      &__comment-nickname {
+        margin: 13px 0 0 0;
       }
     }
     &__post-name {
@@ -136,8 +147,13 @@
       }
     }
     &__pic-box {
+      text-align: center;
       &__picture {
         width: 100%;
+        height: auto;
+      }
+      &__comment-picture {
+        width: 50px;
         height: auto;
       }
     }
@@ -176,6 +192,24 @@
       text-align: center;
       margin: 10px 0;
       word-break: break-all;
+      &__box {
+        width: 365px;
+        height: auto;
+        word-break: break-all;
+        border: 1px solid #f5f3f4;
+        margin: 0 auto;
+        &__text {
+          padding: 5px;
+        }
+      }
+    }
+    .comment-show-path {
+      color: black;
+      text-decoration: none;
+      &__text {
+        font-size: 16px;
+        padding: 5px;
+      }
     }
   }
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -5,6 +5,11 @@ class CommentsController < ApplicationController
     @comment = Comment.new
   end
 
+  def show
+    @post = Post.find( params[:id] )
+    @comments = @post.comments.order('updated_at DESC')
+  end
+
   def create
     @post = Post.find(params[:post_id])
     @comment = Comment.create(comment_params)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,7 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find( params[:id] )
-    @comments = @post.comments.order('updated_at DESC')
+    @comments = @post.comments.order('updated_at DESC').limit(5)
     @comment = Comment.new
   end
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,4 +1,4 @@
-<h2>ユーザーさんからのコメント(<%= @comments.count %>)</h2>
+<h2>ユーザーさんからのコメント(<%= @post.comments.count %>)</h2>
 <div class="detail-comment">
   <div class="detail-comment__box">
     <% if @comments.present? %>
@@ -16,6 +16,7 @@
       <h2>まだコメントはありません</h2>
     <% end %>
   </div>
+  <%= link_to 'コメント一覧', post_comment_path(@post) %>
 </div>
 <% if current_user %>
   <h2>コメントを書く</h2>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,8 +1,49 @@
-<% if user_signed_in? %>
-  <%= form_for [@post, @comment] do |f| %>
-    <%= f.text_area :text, class:"comment-form", id:"textarea" %>
-    <%= f.submit 'コメントする', class:"comment-btn" %>
-  <% end %>
-<% else %>
-  <%= link_to 'ログインしてコメントしよう！', new_user_session_path %>
-<% end %>
+<%= render 'layouts/shared/sp-header' %>
+<div class='sp-main'>
+  <div class='sp-detail'>
+    <div class='sp-detail__post-name'>
+      <%= @post.name %>
+    </div>
+    <div class="sp-detail__pic-box">
+      <% if @post.image.present? %>
+        <%= image_tag @post.image.url, class:'sp-detail__pic-box__comment-picture' %>
+      <% else %>
+        <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="sp-detail__pic-box__comment-picture">
+      <% end %>
+    </div>
+    <h2 class='sp-detail__title'>山のデータ</h2>
+    <div class='sp-detail__description'>
+      <div class='sp-detail__description__name'>
+        山頂標高:
+          <div class='sp-detail__description__count'>
+            <%= @post.elevation %>M
+          </div>
+      </div>
+      <div class='sp-detail__description__name'>
+        歩行距離:
+        <div class='sp-detail__description__count'>
+          <%= @post.walking_distance %>KM
+        </div>
+      </div>
+      <div class='sp-detail__description__name'>
+        <%= @post.difficulty_i18n %>
+      </div>
+    </div>
+    <div class='sp-detail__comment__box'>
+      <h3 class='sp-detail__comment__box__text'>
+        <%= simple_format(@post.text) %>
+      </h3>
+    </div>
+    <% if user_signed_in? %>
+      <%= form_for [@post, @comment] do |f| %>
+        <div class='sp-new-comment-box'>
+          <%= f.text_area :text, class:'sp-new-comment-box__form' %>
+          <%= f.submit 'コメントする', class:'sp-new-comment-box__btn' %>
+        </div>
+      <% end %>
+    <% else %>
+      <%= link_to 'ログインしてコメントしよう！', new_user_session_path, class:'sp-comment-login-link' %>
+    <% end %>
+  </div>
+</div>
+<%= render 'layouts/shared/sp-banner' %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -1,0 +1,4 @@
+<% @comments.each do |comment| %>
+  <%= comment.user.nickname %>さん
+  <%= simple_format(comment.text) %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -65,10 +65,12 @@
 <div class="sp-main">
   <div class="sp-detail">
     <div class="sp-detail__user">
-      <% if @post.user.image.present? %>
-        <%= image_tag @post.user.image.url, class:'sp-detail__user__picture' %>
-      <% else %>
-        <img class="sp-detail__user__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+      <%= link_to @post.user do %>
+        <% if @post.user.image.present? %>
+          <%= image_tag @post.user.image.url, class:'sp-detail__user__picture' %>
+        <% else %>
+          <img class="sp-detail__user__picture" src="https://static.mercdn.net/images/member_photo_noimage_thumb.png">
+        <% end %>
       <% end %>
       <div class="sp-detail__user__nickname"><%= @post.user.nickname %></div>
     </div>
@@ -85,9 +87,11 @@
     <i class='far fa-heart fa-2x'>
       <span><%= @post.likes.count %></span>
     </i>
-    <i class="far fa-comment fa-2x">
-      <span><%= @post.comments.count %></span>
-    </i>
+    <%= link_to new_post_comment_path(post_id: @post.id), method: :get do %>
+      <i class="far fa-comment fa-2x">
+        <span><%= @post.comments.count %></span>
+      </i>
+    <% end %>
     <% if user_signed_in? && current_user.id == @post.user_id %>
       <%= link_to edit_post_path(@post), method: :get, class:'sp-detail__btn' do %>
         <i class="far fa-edit fa-2x"></i>
@@ -114,15 +118,32 @@
         <%= @post.difficulty_i18n %>
       </div>
     </div>
-    <h2 class='sp-detail__title'>一言コメント</h2>
-    <div class='sp-detail__comment'>
-      <%= simple_format(@post.text) %>
+    <div class='sp-detail__comment__box'>
+      <h3 class='sp-detail__comment__box__text'>
+        <%= simple_format(@post.text) %>
+      </h3>
     </div>
-    <h2>ユーザーさんからのコメント(<%= @comments.count %>)</h2>
+    <h2 class='sp-detail__title'>コメント(<%= @post.comments.count %>)</h2>
     <% if @comments.present? %>
       <% @comments.each do |comment| %>
-        <%= comment.user.nickname %>さん
-        <%= simple_format(comment.text) %>
+        <div class="sp-detail__user">
+        <%= link_to comment.user do %>
+          <% if comment.user.image.url.present? %>
+            <%= image_tag comment.user.image.url, class:'sp-detail__user__comment-picture' %>
+          <% else %>
+            <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="sp-detail__user__comment-picture">
+          <% end %>
+        <% end %>
+        <div class='sp-detail__user__comment-nickname'><%= comment.user.nickname %>さん</div>
+        </div>
+        <div class='sp-detail__comment__box'>
+          <h3 class='sp-detail__comment__box__text'>
+            <%= simple_format(comment.text) %>
+          </h3>
+        </div>
+      <% end %>
+      <%= link_to post_comment_path(@post), class:'comment-show-path' do %>
+        <h3 class='comment-show-path__text'>コメント一覧</h3>
       <% end %>
     <% else %>
       <h2>まだコメントはありません</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
 
   resources :posts do
-    resources :comments, only: [:new, :create]
+    resources :comments, only: [:new, :create, :show]
     resources :users, only: [:index, :show]
     collection do
       get 'search'


### PR DESCRIPTION
## WHAT

- コメント投稿ページの作成。
- 投稿詳細ページのコメント一覧（最大表示数５件）の作成。

## WHY

- スマホ用のコメント投稿ページを作成しユーザビリティを向上させる為。
- スマホ用の投稿詳細ページ内で最新のコメント5件を確認できるようにする為。

## IMAGE

- comment#newページ
![スクリーンショット 2019-10-30 17 34 47](https://user-images.githubusercontent.com/51276845/67841537-a9af7000-fb3b-11e9-894a-1bc699603f70.png)
- post#showページのコメント一覧
![スクリーンショット 2019-10-30 17 34 58](https://user-images.githubusercontent.com/51276845/67841571-bd5ad680-fb3b-11e9-8eaa-2579dc71049a.png)

