### PR TITLE
編集/削除ボタンのレイアウト修正

### DIFF
--- a/app/assets/stylesheets/modules/_comment.scss
+++ b/app/assets/stylesheets/modules/_comment.scss
@@ -26,6 +26,26 @@
     &__name {
       padding: 5px;
       margin: 10px;
+      .comment-edit-path {
+        border: 1px solid white;
+        border-radius: 3px;
+        background: white;
+        padding: 3px 5px;
+        text-decoration: none;
+        color: black;
+        margin: 0 30px 0 110px;
+      }
+      .comment-delete-path {
+        border: 1px solid red;
+        border-radius: 3px;
+        background: white;
+        padding: 3px 5px;
+        text-decoration: none;
+        color: black;
+      }
+      .comment-edit-path:hover, .comment-delete-path:hover {
+        opacity: 0.7;
+      }
     }
   }
   .comment-text-area {

--- a/app/assets/stylesheets/posts/show.scss
+++ b/app/assets/stylesheets/posts/show.scss
@@ -128,6 +128,13 @@
       }
       &__comment-nickname {
         margin: 13px 0 0 0;
+        .comment-edit-path {
+          color: black;
+          margin: 0 40px 0 100px;
+        }
+        .comment-delete-path {
+          color: black;
+        }
       }
     }
     &__post-name {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,5 @@
 class CommentsController < ApplicationController
-  before_action :set_post,    only: [:new, :create, :show, :update, :destroy]
+  before_action :set_post,    only: [:new, :create, :show, :edit, :update, :destroy]
   before_action :set_comment, only: [:edit, :update, :destroy]
 
   def new

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,9 +1,10 @@
-編集仮置き
-<%= form_for [@post, @comment], url:{ action: 'update' } do |f| %>
-  <%= f.text_area :text %>
-  <%= f.submit '編集を完了する' %>
-<% end %>
-
+<main>
+  編集仮置き
+  <%= form_for [@post, @comment], url:{ action: 'update' } do |f| %>
+    <%= f.text_area :text %>
+    <%= f.submit '編集を完了する' %>
+  <% end %>
+</main>
 <%= render 'layouts/shared/sp-header' %>
 <div class='sp-main'>
   <%= render 'comments/shared/sp-post-comment' %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,4 +1,17 @@
+編集仮置き
 <%= form_for [@post, @comment], url:{ action: 'update' } do |f| %>
   <%= f.text_area :text %>
   <%= f.submit '編集を完了する' %>
 <% end %>
+
+<%= render 'layouts/shared/sp-header' %>
+<div class='sp-main'>
+  <%= render 'comments/shared/sp-post-comment' %>
+  <%= form_for [@post, @comment], url:{ action: 'update' } do |f| %>
+    <div class='sp-new-comment-box'>
+      <%= f.text_area :text, class:'sp-new-comment-box__form' %>
+      <%= f.submit '編集を完了する', class:'sp-new-comment-box__btn' %>
+    </div>
+  <% end %>
+</div>
+<%= render 'layouts/shared/sp-banner' %>

--- a/app/views/comments/shared/_sp-comment-list.html.erb
+++ b/app/views/comments/shared/_sp-comment-list.html.erb
@@ -2,22 +2,24 @@
 <% if @comments.present? %>
   <% @comments.each do |comment| %>
     <div class="sp-detail__user">
-    <%= link_to comment.user do %>
-      <% if comment.user.image.url.present? %>
-        <%= image_tag comment.user.image.url, class:'sp-detail__user__comment-picture' %>
-      <% else %>
-        <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="sp-detail__user__comment-picture">
+      <%= link_to comment.user do %>
+        <% if comment.user.image.url.present? %>
+          <%= image_tag comment.user.image.url, class:'sp-detail__user__comment-picture' %>
+        <% else %>
+          <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="sp-detail__user__comment-picture">
+        <% end %>
       <% end %>
-    <% end %>
-    <div class='sp-detail__user__comment-nickname'><%= comment.user.nickname %>さん</div>
-    <% if current_user.id == comment.user_id %>
-      <%= link_to edit_post_comment_path(comment.post.id, comment.id), method: :get do %>
-        <i class="far fa-edit"></i>
-      <% end %>
-      <%= link_to post_comment_path(comment.post.id, comment.id), method: :delete, data: { confirm: "本当に削除しますか?" } do %>
-        <i class="far fa-trash-alt"></i>
-      <% end %>
-    <% end %>
+      <div class='sp-detail__user__comment-nickname'>
+        <%= comment.user.nickname %>さん
+        <% if user_signed_in? && current_user.id == comment.user_id %>
+          <%= link_to edit_post_comment_path(comment.post.id, comment.id), method: :get, class:'comment-edit-path' do %>
+            <i class="far fa-edit"></i>
+          <% end %>
+          <%= link_to post_comment_path(comment.post.id, comment.id), method: :delete, data: { confirm: "本当に削除しますか?" }, class:'comment-delete-path' do %>
+            <i class="far fa-trash-alt"></i>
+          <% end %>
+        <% end %>
+      </div>
     </div>
     <div class='sp-detail__comment__box'>
       <h3 class='sp-detail__comment__box__text'>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -15,11 +15,11 @@
             <% end %>
             <div class="comment-user__name">
               <%= comment.user.nickname %>さん
+              <% if current_user.id == comment.user_id %>
+                <%= link_to '編集', edit_post_comment_path(comment.post.id, comment.id), method: :get, class:'comment-edit-path' %>
+                <%= link_to '削除', post_comment_path(comment.post.id, comment.id), method: :delete, data: { confirm: "本当に削除しますか?" }, class:'comment-delete-path' %>
+              <% end %>
             </div>
-            <% if current_user.id == comment.user_id %>
-              <%= link_to '削除する', post_comment_path(comment.post.id, comment.id), method: :delete, data: { confirm: "本当に削除しますか?" } %>
-              <%= link_to '編集する', edit_post_comment_path(comment.post.id, comment.id), method: :get %>
-            <% end %>
           </div>
           <div class="comment-text-area">
             <%= simple_format(comment.text) %>


### PR DESCRIPTION
## WHAT

- 編集/削除ボタンのレイアウトの修正。

## WHY

- ボタンの間隔が狭く押しにくいので、間隔を広げて右よりに配置する事で押し間違いをしないようにする為。

## IMAGE

- スマホ用編集ページ
![スクリーンショット 2019-10-30 21 38 58](https://user-images.githubusercontent.com/51276845/67858981-d96f6f80-fb5d-11e9-9c2c-ead2b0c10c6f.png)
- スマホ用編集/削除ボタン
![スクリーンショット 2019-10-30 21 39 25](https://user-images.githubusercontent.com/51276845/67859005-e55b3180-fb5d-11e9-8b1f-0b2e4c10000a.png)
- PC用編集/削除ボタン
![スクリーンショット 2019-10-30 21 39 11](https://user-images.githubusercontent.com/51276845/67859063-03c12d00-fb5e-11e9-93e3-94495412f3dc.png)

