### PR TITLE
ランキング表示の修正

### DIFF
--- a/app/assets/stylesheets/modules/_lists.scss
+++ b/app/assets/stylesheets/modules/_lists.scss
@@ -169,6 +169,15 @@
       &__ranking {
         font-size: 32px;
       }
+      #ranking-1 {
+        color: #DBB400;
+      }
+      #ranking-2 {
+        color: #9FA0A0;
+      }
+      #ranking-3 {
+        color: #C47022;
+      }
       &__profile {
         padding: 10px 0;
       }

--- a/app/views/posts/partial/_ranking-lists.html.erb
+++ b/app/views/posts/partial/_ranking-lists.html.erb
@@ -4,8 +4,8 @@
       <div class='box-left'>
         <%= yama_horizontal_list_image(post) %>
         <div class='item-description'>
-          <div class='item-description__ranking'>
-            <%="第#{i}位"%>
+          <div id='ranking-<%= i %>'class='item-description__ranking'>
+            <%="No.#{i}"%>
           </div>
           <div class='item-description__profile'><%= post.user.nickname %>さんの投稿</div>
           <div class='item-description__name'>

--- a/app/views/rankings/index.html.erb
+++ b/app/views/rankings/index.html.erb
@@ -1,30 +1,26 @@
 <%= render 'layouts/shared/sp-header' %>
-<h1 class="sp-top-home">ランキング</h1>
-<div class="sp-main">
-  <div class="sp-list-box">
+<h1 class='sp-top-home'>ランキング</h1>
+<div class='sp-main'>
+  <div class='sp-list-box'>
     <% @all_ranks.each.with_index(1) do |post, i| %>
-      <%= link_to post_path(post),data: {"turbolinks"=>false} do %>
-        <div id="ranking-<%= i %>" class="sp-list-box__ranking">
+      <%= link_to post_path(post) do %>
+        <div id='ranking-<%= i %>' class='sp-list-box__ranking'>
           <%="No.#{i}"%>
         </div>
-        <div class="sp-post-box">
-          <% if post.image.present? %>
-            <%= image_tag post.image.url, class:"sp-post-box__picture"%>
-          <% else %>
-            <img src="https://mgs01y1.wowma.net/pc/img/common/no_image300.gif?query=201908071342" alt="" class="sp-post-box__picture">
-          <% end %>
-          <div class="sp-post-box__description">
+        <div class='sp-post-box'>
+          <%= yama_index_list_image(post) %>
+          <div class='sp-post-box__description'>
             <label><%= post.user.nickname %></label><br/>
             <%= post.name %>
-            <div class="sp-post-box__description__comment">
+            <div class='sp-post-box__description__comment'>
               <%= post.text %>
             </div>
           </div>
         </div>
       <% end %>
-      <div class="sp-post-box__like">
+      <div class='sp-post-box__like'>
         <%= render 'likes/like-links', post: post %>
-        <i class="far fa-comment fa-2x">
+        <i class='far fa-comment fa-2x'>
           <span><%= post.comments.count %></span>
         </i>
       </div>


### PR DESCRIPTION
## WHAT

- PC用のランキング表示の１位〜３位までのcssを変更。

## WHY

- PC用でも金・銀・銅のcssを指定し、ランキングの順位を分かりやすく区別する為。