### PR TITLE
コメント機能のajax化

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require activestorage
 //= require_tree .

--- a/app/assets/javascripts/comment.js
+++ b/app/assets/javascripts/comment.js
@@ -1,0 +1,39 @@
+$(function() {
+  function buildHTML(comment){
+    var html =`<div class="comment-user">
+                <a href="/users/${comment.user_id}">
+                  <img class="comment-user__comment-picture" src="${comment.image}">
+                </a>
+                <div class="comment-user__name">
+                  ${comment.user_name}
+                </div>
+              </div>
+              <div class="comment-text-area">
+                <p>${comment.text}</p>
+              </div>`
+    return html;
+  }
+  $('#new_comment').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action')
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data) {
+      var html = buildHTML(data);
+      $('.detail-comment').append(html);
+      $('textbox').val(' ');
+      $('#new_comment')[0].reset();
+      $('.form__submit').prop('disabled', false);
+    })
+    .fail(function() {
+      alert('error');
+    })
+  })
+})

--- a/app/assets/stylesheets/modules/_comment.scss
+++ b/app/assets/stylesheets/modules/_comment.scss
@@ -7,10 +7,6 @@
   border-radius: 3px;
   padding: 10px;
   word-break : break-all;
-  &__box {
-    overflow-y: scroll;
-    height: 300px;
-  }
   .comment-user {
     padding: 5px;
     margin: 10px 0 0 0;

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,12 +12,9 @@ class CommentsController < ApplicationController
 
   def create
     @comment = Comment.create(comment_params)
-    if @comment.save
-      flash[:success] = "コメントが完了しました！"
-      redirect_to post_path(@post.id)
-    else
-      flash.now[:alert] = "失敗しました。"
-        redirect_back(fallback_location: root_path)
+    respond_to do |format|
+      format.html { redirect_to post_path(@post.id)}
+      format.json
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
   end
 
   def show
-    @comments = @post.comments.order('updated_at DESC').limit(5)
+    @comments = @post.comments.last(5)
     @comment = Comment.new
   end
 

--- a/app/views/comments/create.json.jbuilder
+++ b/app/views/comments/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text      @comment.text
+json.user_id   @comment.user.id
+json.user_name @comment.user.nickname
+json.image     @comment.user.image.url

--- a/app/views/comments/partial/_comment.html.erb
+++ b/app/views/comments/partial/_comment.html.erb
@@ -19,15 +19,15 @@
       <h2>まだコメントはありません</h2>
     <% end %>
   </div>
-  <%= link_to 'コメント一覧', post_comment_path(@post), class:'comment-link-path' %>
 </div>
+<%= link_to 'コメント一覧', post_comment_path(@post), class:'comment-link-path' %>
 <% if current_user %>
   <h2>コメントを書く</h2>
   <div class='detail-description'>
     <div class='detail-description__display'>
-      <%= form_for [@post, @comment] do |f| %>
-        <%= f.text_area :text, class:'comment-form', id:'textarea' %>
-        <%= f.submit 'コメントする', class:'comment-btn' %>
+      <%= form_for [@post, @comment], id: 'new_comment' do |f| %>
+        <%= f.text_area :text, class:'comment-form textbox', id:'textarea' %>
+        <%= f.submit 'コメントする', class:'comment-btn form__submit' %>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/partial/_sp-index.html.erb
+++ b/app/views/posts/partial/_sp-index.html.erb
@@ -12,7 +12,7 @@
 <% end %>
 <div class="sp-post-box__like">
   <%= render 'likes/like-links', post: post %>
-  <%= link_to new_post_comment_path(post_id: post.id), method: :get do %>
+  <%= link_to post_path(post) do %>
     <i class="far fa-comment fa-2x">
       <span><%= post.comments.count %></span>
     </i>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -77,7 +77,7 @@
     <i class='far fa-heart fa-2x'>
       <span><%= @post.likes.count %></span>
     </i>
-    <%= link_to new_post_comment_path(post_id: @post.id), method: :get do %>
+    <%= link_to post_comment_path(@post) do %>
       <i class="far fa-comment fa-2x">
         <span><%= @post.comments.count %></span>
       </i>
@@ -114,5 +114,15 @@
       </h3>
     </div>
     <%= render 'comments/shared/sp-comment-list' %>
+    <% if current_user %>
+      <div class='sp-new-comment-box''>
+        <%= form_for [@post, @comment] do |f| %>
+          <%= f.text_area :text, class:'sp-new-comment-box__form' %>
+          <%= f.submit 'コメントする', class:'sp-new-comment__btn' %>
+        <% end %>
+      </div>
+    <% else %>
+      <%= link_to 'ログインしてコメントしよう！', new_user_session_path, class:'sp-comment-login-link' %>
+    <% end %>
 </div>
 <%= render "layouts/shared/sp-banner" %>


### PR DESCRIPTION
## WHAT

- PC用コメント機能をajax化。
- スマホ用コメント機能の移植。

## WHY

- コメントする度にhttpリクエストされてしまうのでajax化しユーザビリティを向上させる為。
- スマホ用コメントajax化によってスマホ用のコメントページが不具合が生じた為posts#showページへ移植。

## 備考
- [スマホ]comments#newページへは一旦、飛べないようにしている。