### PR TITLE
検索機能の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
 
   def search
     if params[:q].present?
-      @search_result = @search.result.page(params[:page]).per(20)
+      @search_result = @search.result.where.not(user_id: current_user.id).page(params[:page]).per(20)
     else
       render :search
     end


### PR DESCRIPTION
## WHAT

- ransackを使った検索結果の表示の修正。

## WHY

- 検索結果に自分の投稿が含まれないようにする為。投稿を検索する際に自分の投稿まで含まれて検索結果が表示されるとページ数も多くなりユーザーフレンドリーではないと感じた為。