### PR TITLE
投稿一覧表示の修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
 
   def index
     @all_ranks = Post.create_all_ranks
-    @posts = Post.includes(:user, :likes, :comments, :meal).order('updated_at DESC')
+    @posts = Post.includes(:user, :likes, :comments, :meal).where.not(user_id: current_user.id).order('updated_at DESC')
     @users = User.order('updated_at DESC')
     @meals = Meal.includes(:post).order('updated_at DESC')
     if user_signed_in?

--- a/db/migrate/20191115060551_add_lead_flag_to_posts.rb
+++ b/db/migrate/20191115060551_add_lead_flag_to_posts.rb
@@ -1,0 +1,5 @@
+class AddLeadFlagToPosts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :posts, :lead_flag, :integer
+  end
+end

--- a/db/migrate/20191115072643_remove_lead_flag_from_posts.rb
+++ b/db/migrate/20191115072643_remove_lead_flag_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveLeadFlagFromPosts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :posts, :lead_flag, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_09_100511) do
+ActiveRecord::Schema.define(version: 2019_11_15_072643) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"


### PR DESCRIPTION
## WHAT

- 投稿一覧にログインユーザーの投稿も表示されていたので他ユーザーの投稿のみ表示できるように修正。

## WHY

- ログインユーザーは自身の投稿表示が別窓で用意されており、他ユーザーの投稿と一緒に表示される必要性が無いと判断した為。