### PR TITLE
Mealモデルのカラム変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -91,7 +91,8 @@ class PostsController < ApplicationController
                         :image,
                         :cooking_time,
                         :food_stuff,
-                        :cooking_method]
+                        :cooking_method,
+                        :user_id]
     ).merge(user_id: current_user.id)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @meals = @user.meals.order("created_at DESC")
     @posts = @user.posts.order("created_at DESC").page(params[:page]).per(5)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :posts,    dependent: :destroy
+  has_many :meals,    dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :likes,    dependent: :destroy
   has_many :like_posts, through: :likes, source: :post

--- a/app/views/layouts/shared/_sp-header.html.erb
+++ b/app/views/layouts/shared/_sp-header.html.erb
@@ -4,7 +4,9 @@
       <h1 class='logo-box__sp-logo'>岳人</h1>
       <h3 class='logo-box__sp-kana'>〜たけと〜</h3>
     <% end %>
-    <%= sp_header_login_image %>
+    <%= link_to @user do %>
+      <%= sp_header_login_image %>
+    <% end %>
     <%# チェックボックス。常に非表示。 %>
     <input id='nav-input' type='checkbox' class='nav-unshown'>
     <%# チェックボックスのラベル。ここで三アイコンを表示。タップによりinputがチェック状態に。 %>

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -1,22 +1,7 @@
 <div class='sp-main'>
   <%= render 'layouts/shared/sp-header' %>
   <h1 class='sp-top-home'>山メシ</h1>
-  <% @meals.each do |meal| %>
-    <div class='sp-list-box'>
-      <%= link_to meal_path(meal) do %>
-        <div class='sp-post-box'>
-          <%= meshi_index_page_image(meal) %>
-          <div class='sp-post-box__description'>
-            <label><%= meal.name %></label><br/>
-            調理時間:<%= meal.cooking_time %>分
-            <div class='sp-post-box__description__comment'>
-              調理方法:<%= meal.cooking_method %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
+  <%= render 'meals/shared/sp-meshi-lists' %>
   <%= render 'layouts/shared/sp-button' %>
   <%= render 'layouts/shared/sp-banner' %>
 </div>

--- a/app/views/meals/shared/_sp-meshi-lists.html.erb
+++ b/app/views/meals/shared/_sp-meshi-lists.html.erb
@@ -1,0 +1,16 @@
+<% @meals.each do |meal| %>
+  <div class='sp-list-box'>
+    <%= link_to meal_path(meal) do %>
+      <div class='sp-post-box'>
+        <%= meshi_index_page_image(meal) %>
+        <div class='sp-post-box__description'>
+          <label><%= meal.name %></label><br/>
+          調理時間:<%= meal.cooking_time %>分
+          <div class='sp-post-box__description__comment'>
+            調理方法:<%= meal.cooking_method %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/posts/partial/_new-post.html.erb
+++ b/app/views/posts/partial/_new-post.html.erb
@@ -65,6 +65,7 @@
   </div>
 
   <%= f.fields_for :meal do |s| %>
+    <%= s.hidden_field :user_id, value: current_user.id %>
     <div class='form-registration-box'>
       <%= s.label :山メシの名前, class:'form-registration-box__name' %>
       <%= s.label :必須, class:'form-registration-box__require' %>

--- a/app/views/posts/partial/_sp-new-post.html.erb
+++ b/app/views/posts/partial/_sp-new-post.html.erb
@@ -55,6 +55,7 @@
   </div>
 
   <%= f.fields_for :meal do |s| %>
+    <%= s.hidden_field :user_id, value: current_user.id %>
     <div class='form-registration-box'>
       <%= s.label :山メシの名前, class:'form-registration-box__name' %>
       <%= s.label :必須, class:'form-registration-box__require' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -53,10 +53,13 @@
     </div>
   </div>
   <% if @user.posts.any? %>
-    <h2 class='sp-posts-count'>投稿一覧 (<%= @user.posts.count %>)</h2>
+    <h2 class='sp-posts-count'>投稿一覧 (<%= @user.posts.count + @user.meals.count %>)</h2>
     <div class="sp-list-box">
       <%= render partial: 'posts/partial/sp-index', collection: @posts, as:'post'%>
     </div>
+    <% if @user.meals.any? %>
+      <%= render 'meals/shared/sp-meshi-lists' %>
+    <% end %>
   <% else %>
     <h2 class='sp-posts-count'>まだ投稿はありません</h2>
   <% end %>

--- a/db/migrate/20191003050623_add_user_id_to_meals.rb
+++ b/db/migrate/20191003050623_add_user_id_to_meals.rb
@@ -1,5 +1,5 @@
 class AddUserIdToMeals < ActiveRecord::Migration[5.2]
   def change
-    add_column :meals, :user_id, :integer
+    add_column :meals, :user_id, :integer, null: false
   end
 end

--- a/db/migrate/20191009100238_add_post_id_to_meals.rb
+++ b/db/migrate/20191009100238_add_post_id_to_meals.rb
@@ -1,5 +1,5 @@
 class AddPostIdToMeals < ActiveRecord::Migration[5.2]
   def change
-    add_column :meals, :post_id, :integer
+    add_column :meals, :post_id, :integer, null: false
   end
 end

--- a/db/migrate/20191009100511_remove_user_id_from_meals.rb
+++ b/db/migrate/20191009100511_remove_user_id_from_meals.rb
@@ -1,5 +1,0 @@
-class RemoveUserIdFromMeals < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :meals, :user_id, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,7 +35,8 @@ ActiveRecord::Schema.define(version: 2019_11_16_121458) do
     t.text "cooking_method"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "post_id"
+    t.integer "user_id", null: false
+    t.integer "post_id", null: false
   end
 
   create_table "posts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,6 +28,7 @@ end
 10.times do |m|
   m += 1
   Meal.create!(
+    user_id:                "#{m}",
     post_id:                "#{m}",
     name:                   "テスト飯#{m}",
     image:                  open("#{Rails.root}/db/fixtures/カレー.jpeg"),


### PR DESCRIPTION
## WHAT

- mealモデルにuser_idカラムを追加。
- posts#createアクションで子モデルmealにuser_idが保存できるようにhidden_fieldを作成。

## WHY

- 現状の仕様だと@user.mealなどのアソシエーションを組めていなかった為。
- postモデルとmealモデルの両方がビュー側で表示できるようにする為。