### PR TITLE
レスポンシブヘッダーの修正

### DIFF
--- a/app/assets/stylesheets/modules/_notification.scss
+++ b/app/assets/stylesheets/modules/_notification.scss
@@ -7,6 +7,12 @@ h1.notification-page {
 .notification-article {
   display: flex;
   justify-content: center;
+  position: relative;
+  &__text {
+    font-size: 24px;
+    text-align: center;
+    margin: 10px;
+  }
 }
 .notification-section-left {
   &__image {

--- a/app/assets/stylesheets/mypage.scss
+++ b/app/assets/stylesheets/mypage.scss
@@ -77,6 +77,22 @@
       color: white;
       text-align: center;
     }
+    &__notification-nav {
+      position: absolute;
+      right: 90px;
+      top: 3%;
+      .fa-bell {
+        color: white;
+      }
+      .n-circle {
+        position: absolute;
+        top: 3%;
+        right: 10px;
+        padding-left: 1rem;
+        padding-top: 0rem;
+        color: #efa04c;
+      }
+    }
   }
   .wrapper {
     position: absolute;

--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -3,6 +3,9 @@
     <%= link_to tab_posts_path, class:'footer-list__link' do %>
       <div class='footer-list__information'>このサイトについて</div>
     <% end %>
+    <%= link_to root_path, class:'footer-list__link' do %>
+      <div class='footer-list__information'>ホームへ戻る</div>
+    <% end %>
   </div>
   <div class='footer-main__copyright'>
     <a>Copyright（C） 2019　kohei sugawara All Rights Reserved.</a>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -6,7 +6,7 @@
     <%= render notifications %>
     <%= paginate notifications %>
   <% else %>
-    <p>通知がありません</p>
+    <p class='notification-article__text'>通知がありません</p>
   <% end %>
   <%= render 'layouts/shared/footer' %>
 </main>

--- a/app/views/users/shared/_login-header.html.erb
+++ b/app/views/users/shared/_login-header.html.erb
@@ -6,7 +6,18 @@
       <span></span>
     </div>
   </div>
-
+  <div class='mypage-header__notification-nav'>
+    <%= link_to(notifications_path) do %>
+      <% if unchecked_notifications.any? %>
+        <span class='fa-stack'>
+          <i class="far fa-bell fa-2x"></i>
+          <i class='fas fa-circle n-circle fa stack-1x'></i>
+        </span>
+      <% else %>
+        <i class='far fa-bell fa-2x'></i>
+      <% end %>
+    <% end %>
+  </div>
   <div id="gloval-nav">
     <% if signed_in? %>
       <nav>


### PR DESCRIPTION
## WHAT

- ヘッダーに通知ベルアイコンを設置。

## WHY

- 501px~1024pxの画面幅に合わせて通知ベルアイコンをヘッダー内に設置し通知を確認できるようにする為。

## IMAGE

![スクリーンショット 2019-11-28 16 12 56](https://user-images.githubusercontent.com/51276845/69787012-ecc63700-11fe-11ea-9eaf-1b8b475aec70.png)
